### PR TITLE
Fix code scanning alert no. 2: Clear-text logging of sensitive information

### DIFF
--- a/bitcoin_safe/gui/qt/dialogs.py
+++ b/bitcoin_safe/gui/qt/dialogs.py
@@ -285,6 +285,6 @@ if __name__ == "__main__":
     dialog = PasswordCreation()
     password = dialog.get_password()
     if password:
-        print(f"Password created: {password}")
+        print("Password created successfully.")
     sys.exit(app.exec())
     quit()


### PR DESCRIPTION
Fixes [https://github.com/andreasgriffin/bitcoin-safe/security/code-scanning/2](https://github.com/andreasgriffin/bitcoin-safe/security/code-scanning/2)

To fix the problem, we need to ensure that sensitive information such as passwords is not logged in clear text. Instead of logging the actual password, we can log a generic message indicating that a password was created without revealing the password itself. This change will maintain the functionality of informing that a password was created while protecting the sensitive information.

We will modify the line that logs the password to log a generic message instead. No additional imports or methods are needed for this change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
