### PR TITLE
Add missing dependencies to `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@
 Install dependencies: 
 
   ```sh
-  sudo apt install  qt6-tools-dev-tools libqt6*
+  sudo apt install  qt6-tools-dev-tools libqt6* libsecp256k1-0 libxcb-cursor0
   ```
 
 - Install `poetry` and run `bitcoin_safe`

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@
 ## Installation from Git repository
 
 
-### Ubuntu, Debian, Windows
+### Ubuntu, Debian
 
 Install dependencies: 
 
@@ -141,13 +141,18 @@ Install dependencies:
   python3 -m pip install poetry && python3 -m poetry install && python3 -m poetry run python3 -m bitcoin_safe
   ```
 
+- `libsecp256k1`
+  ```sh
+  /bin/bash ./tools/make_libsecp256k1.sh
+  ```
+
 - *Optional*: dependency `zbar`
   
   ```sh
   xcode-select --install
   /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
   brew install zbar 
-  ```
+  ``` 
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@
 
 ### Ubuntu, Debian
 
-Install dependencies: 
+- Install dependencies: 
 
   ```sh
   sudo apt-get install qt6-tools-dev-tools libxcb-cursor0 '^libsecp256k1-.*$' '^libqt6.*$'

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@
 Install dependencies: 
 
   ```sh
-  sudo apt install  qt6-tools-dev-tools libqt6* libsecp256k1-0 libxcb-cursor0
+  sudo apt-get install qt6-tools-dev-tools libxcb-cursor0 '^libsecp256k1-.*$' '^libqt6.*$'
   ```
 
 - Install `poetry` and run `bitcoin_safe`


### PR DESCRIPTION
Otherwise, installation fails with:

```
Uncaught exception
Traceback (most recent call last):
  File "/usr/lib/python3.10/runpy.py", line 196, in _run_module_as_main
return _run_code(code, main_globals, None,
  File "/usr/lib/python3.10/runpy.py", line 86, in _run_code
exec(code, run_globals)
  File "bitcoin_safe/__main__.py", line 20, in <module>
from bitcoin_safe.gui.qt.main import MainWindow
  File "bitcoin_safe/gui/qt/main.py", line 62, in <module>
from bitcoin_safe.gui.qt.descriptor_edit import DescriptorExport
  File "bitcoin_safe/gui/qt/descriptor_edit.py", line 46, in <module>
from bitcoin_safe.gui.qt.export_data import ExportDataSimple
  File "bitcoin_safe/gui/qt/export_data.py", line 61, in <module>
from bitcoin_safe.descriptor_export_tools import DescriptorExportTools
  File "bitcoin_safe/descriptor_export_tools.py", line 40, in <module>
from bitcoin_safe.wallet import filename_clean
  File "bitcoin_safe/wallet.py", line 43, in <module>
from bitcoin_usb.psbt_tools import PSBTTools
  File ".venv/lib/python3.10/site-packages/bitcoin_usb/psbt_tools.py", line 9, in <module>
from bitcointx.core.key import BIP32Path
  File ".venv/lib/python3.10/site-packages/bitcointx/core/__init__.py", line 25, in <module>
from . import script
  File ".venv/lib/python3.10/site-packages/bitcointx/core/script.py", line 31, in <module>
import bitcointx.core.key
  File ".venv/lib/python3.10/site-packages/bitcointx/core/key.py", line 36, in <module>
from bitcointx.core.secp256k1 import (
  File ".venv/lib/python3.10/site-packages/bitcointx/core/secp256k1.py", line 291, in <module>
_secp256k1 = load_secp256k1_library(bitcointx.util._secp256k1_library_path)
  File ".venv/lib/python3.10/site-packages/bitcointx/core/secp256k1.py", line 276, in load_secp256k1_library
raise ImportError('secp256k1 library not found')
ImportError: secp256k1 library not found
```

```
2025-03-29 12:47:28,148 - WARNING - [MainThread] - bitcoin_safe.logging_setup - From 6.5.0, xcb-cursor0 or libxcb-cursor0 is needed to load the Qt xcb platform plugin.
2025-03-29 12:47:28,148 - INFO - [MainThread] - bitcoin_safe.logging_setup - Could not load the Qt platform plugin "xcb" in "" even though it was found.
2025-03-29 12:47:28,148 - CRITICAL - [MainThread] - bitcoin_safe.logging_setup - This application failed to start because no Qt platform plugin could be initialized. Reinstalling the application may fix this problem.
```