### PR TITLE
Fix addess balance  for spent utxos

### DIFF
--- a/bitcoin_safe/wallet.py
+++ b/bitcoin_safe/wallet.py
@@ -1218,6 +1218,8 @@ class Wallet(BaseSaveableClass, CacheManager):
 
         balances: defaultdict[str, Balance] = defaultdict(Balance)
         for i, utxo in enumerate(utxos):
+            if utxo.is_spent:
+                continue
             outpoint = OutPoint.from_bdk(utxo.outpoint)
             txout = self.get_txout_of_outpoint(outpoint)
             if not txout:


### PR DESCRIPTION
## Required

- [ ] `pre-commit install` before any commit. If pre-commit wasn't run for all commits, you can squash all commits   `git reset --soft $(git merge-base main HEAD) && git commit -m "squash"` and ensure the squashed commit is properly formatted
- [ ] All commits must be signed. If some are not, you can squash all commits   `git reset --soft $(git merge-base main HEAD) && git commit -m "squash"` and ensure the squashed commit is signed
- [ ] Update all translations
 
## Optional

- [ ] Appropriate pytests were added
- [ ] Documentation is updated
