### PR TITLE
Workflow: Fix all workflows for custom commit hashes

### DIFF
--- a/.github/workflows/build-and-test-mac.yml
+++ b/.github/workflows/build-and-test-mac.yml
@@ -22,11 +22,19 @@ jobs:
           - os: macos-13
             artifact_name: dmgs-x86_64
     steps:
-      - name: Checkout repository
+      # 1) clone the default branch with full history
+      - name: Checkout default branch
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0  # Fetch all history for all branches and tags
-          ref: ${{ github.event.inputs.commitHash || github.sha }}
+          fetch-depth: 0
+
+      # 2) if a SHA was provided, fetch it and switch to it
+      - name: Fetch and checkout custom commit
+        if: ${{ github.event.inputs.commitHash != '' }}
+        run: |
+          # this will succeed as long as the commit is reachable from ANY branch on the remote
+          git fetch origin ${{ github.event.inputs.commitHash }}
+          git checkout ${{ github.event.inputs.commitHash }}           
 
       - name: Set up Python environment
         uses: actions/setup-python@v5

--- a/.github/workflows/build-appimage.yml
+++ b/.github/workflows/build-appimage.yml
@@ -29,6 +29,7 @@ jobs:
           # this will succeed as long as the commit is reachable from ANY branch on the remote
           git fetch origin ${{ github.event.inputs.commitHash }}
           git checkout ${{ github.event.inputs.commitHash }}
+          
       - name: Set up Python environment
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -16,12 +16,19 @@ jobs:
   build:
     runs-on: ubuntu-22.04
     steps:
-      - name: Checkout repository
+      # 1) clone the default branch with full history
+      - name: Checkout default branch
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0  # Fetch all history for all branches and tags
-          ref: ${{ github.event.inputs.commitHash || github.sha }}
+          fetch-depth: 0
 
+      # 2) if a SHA was provided, fetch it and switch to it
+      - name: Fetch and checkout custom commit
+        if: ${{ github.event.inputs.commitHash != '' }}
+        run: |
+          # this will succeed as long as the commit is reachable from ANY branch on the remote
+          git fetch origin ${{ github.event.inputs.commitHash }}
+          git checkout ${{ github.event.inputs.commitHash }}
 
       - name: Set up Python environment
         uses: actions/setup-python@v5


### PR DESCRIPTION
## Required

- [ ] `pre-commit install` before any commit. If pre-commit wasn't run for all commits, you can squash all commits   `git reset --soft $(git merge-base main HEAD) && git commit -m "squash"` and ensure the squashed commit is properly formatted
- [ ] All commits must be signed. If some are not, you can squash all commits   `git reset --soft $(git merge-base main HEAD) && git commit -m "squash"` and ensure the squashed commit is signed
- [ ] Update all translations
 
## Optional

- [ ] Appropriate pytests were added
- [ ] Documentation is updated
