### PR TITLE
Build script: Remove tty requirement from docker run

### DIFF
--- a/tools/build.py
+++ b/tools/build.py
@@ -249,7 +249,7 @@ class Builder:
             f'-v "{PROJECT_ROOT_OR_FRESHCLONE_ROOT}":/opt/wine64/drive_c/bitcoin_safe '
             f"--rm "
             f"--workdir /opt/wine64/drive_c/bitcoin_safe/{build_folder} "
-            f"  -it   {docker_image} "
+            f"  -i   {docker_image} "
             f"./run_in_docker.sh"
         )
 


### PR DESCRIPTION
- preserves full debugging if  `breakpoint` is set

## Required

- [ ] `pre-commit install` before any commit. If pre-commit wasn't run for all commits, you can squash all commits   `git reset --soft $(git merge-base main HEAD) && git commit -m "squash"` and ensure the squashed commit is properly formatted
- [ ] All commits must be signed. If some are not, you can squash all commits   `git reset --soft $(git merge-base main HEAD) && git commit -m "squash"` and ensure the squashed commit is signed
- [ ] Update all translations
 
## Optional

- [ ] Appropriate pytests were added
- [ ] Documentation is updated
