### PR TITLE
Peek addresses for addressedit color check

### DIFF
--- a/bitcoin_safe/gui/qt/address_edit.py
+++ b/bitcoin_safe/gui/qt/address_edit.py
@@ -28,7 +28,7 @@
 
 
 import logging
-from typing import Optional, cast
+from typing import List, Optional, cast
 
 import bdkpython as bdk
 from bitcoin_qr_tools.data import Data, DataType
@@ -38,6 +38,7 @@ from PyQt6.QtWidgets import QMessageBox, QSizePolicy
 
 from bitcoin_safe.gui.qt.analyzers import AddressAnalyzer
 from bitcoin_safe.gui.qt.buttonedit import ButtonEdit, SquareButton
+from bitcoin_safe.pythonbdk_types import AddressInfoMin
 from bitcoin_safe.typestubs import TypedPyQtSignalNo
 from bitcoin_safe.util_os import webopen
 
@@ -158,14 +159,40 @@ class AddressEdit(ButtonEdit):
 
         self.signal_text_change.emit(self.address)
 
-    @staticmethod
-    def color_address(address: str, wallet: Wallet) -> Optional[QtGui.QColor]:
-        if wallet.is_my_address(address):
-            if wallet.is_change(address):
+    @classmethod
+    def advance_to_address_info(
+        cls, address_info: AddressInfoMin, wallet: Wallet, signals: Signals
+    ) -> List[bdk.AddressInfo]:
+        revealed_address_infos: List[bdk.AddressInfo] = []
+        if address_info.index > wallet.get_tip(is_change=address_info.is_change()):
+            revealed_address_infos += wallet.advance_tip_if_necessary(
+                is_change=address_info.is_change(), target=address_info.index
+            )
+            signals.wallet_signals[wallet.id].updated.emit(
+                UpdateFilter(
+                    addresses=set([str(address_info.address) for address_info in revealed_address_infos]),
+                    reason=UpdateFilterReason.NewAddressRevealed,
+                )
+            )
+        return revealed_address_infos
+
+    @classmethod
+    def color_address(cls, address: str, wallet: Wallet, signals: Signals) -> Optional[QtGui.QColor]:
+        def get_color(is_change: bool) -> QtGui.QColor:
+            if is_change:
                 return ColorScheme.YELLOW.as_color(background=True)
             else:
                 return ColorScheme.GREEN.as_color(background=True)
-        return None
+
+        if wallet.is_my_address(address):
+            return get_color(is_change=wallet.is_change(address))
+        else:
+            address_info = wallet.is_my_address_with_peek(address=address)
+            if not address_info:
+                return None
+
+            cls.advance_to_address_info(address_info=address_info, wallet=wallet, signals=signals)
+            return get_color(is_change=address_info.is_change())
 
     def format_address_field(self, wallet: Optional[Wallet]) -> None:
         palette = QtGui.QPalette()
@@ -173,7 +200,7 @@ class AddressEdit(ButtonEdit):
 
         background_color = None
         if wallet:
-            background_color = self.color_address(self.address, wallet)
+            background_color = self.color_address(self.address, wallet, signals=self.signals)
 
         if background_color:
             palette.setColor(QtGui.QPalette.ColorRole.Base, background_color)

--- a/bitcoin_safe/gui/qt/labeledit.py
+++ b/bitcoin_safe/gui/qt/labeledit.py
@@ -232,7 +232,7 @@ class WalletLabelAndCategoryEdit(LabelAndCategoryEdit):
 
         if self.label_type in [LabelType.addr]:
             for wallet in wallets:
-                if wallet.is_my_address(ref):
+                if wallet.is_my_address_with_peek(ref):
                     result.add(wallet)
                 elif wallet.get_label_for_address(ref):
                     result.add(wallet)

--- a/bitcoin_safe/gui/qt/sankey_bitcoin.py
+++ b/bitcoin_safe/gui/qt/sankey_bitcoin.py
@@ -49,7 +49,12 @@ from bitcoin_safe.pythonbdk_types import (
     robust_address_str_from_script,
 )
 from bitcoin_safe.signals import Signals, UpdateFilter
-from bitcoin_safe.wallet import Wallet, get_label_from_any_wallet, get_wallets
+from bitcoin_safe.wallet import (
+    Wallet,
+    get_label_from_any_wallet,
+    get_wallet_of_address,
+    get_wallets,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -300,16 +305,10 @@ class SankeyBitcoin(SankeyWidget):
         return True
 
     def get_address_color(self, address: str, wallets: List[Wallet]) -> QColor | None:
-        def get_wallet():
-            for wallet in wallets:
-                if wallet.is_my_address(address):
-                    return wallet
-            return None
-
-        wallet = get_wallet()
+        wallet = get_wallet_of_address(address=address, signals=self.signals)
         if not wallet:
             return None
-        color = AddressEdit.color_address(address, wallet)
+        color = AddressEdit.color_address(address, wallet, signals=self.signals)
         if not color:
             logger.error("This should not happen, since wallet should only be found if the address is mine.")
             return None

--- a/bitcoin_safe/gui/qt/tx_util.py
+++ b/bitcoin_safe/gui/qt/tx_util.py
@@ -1,0 +1,72 @@
+#
+# Bitcoin Safe
+# Copyright (C) 2024 Andreas Griffin
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of version 3 of the GNU General Public License as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see https://www.gnu.org/licenses/gpl-3.0.html
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+# BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+# ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
+import logging
+from typing import List
+
+import bdkpython as bdk
+
+from bitcoin_safe.pythonbdk_types import AddressInfoMin
+
+from ...signals import Signals, UpdateFilter, UpdateFilterReason
+from ...wallet import Wallet, get_wallet_of_address
+
+logger = logging.getLogger(__name__)
+
+
+def advance_tip_to_address_info(
+    address_info: AddressInfoMin, wallet: Wallet, signals: Signals
+) -> List[bdk.AddressInfo]:
+    revealed_address_infos: List[bdk.AddressInfo] = []
+    if address_info.index > wallet.get_tip(is_change=address_info.is_change()):
+        revealed_address_infos += wallet.advance_tip_if_necessary(
+            is_change=address_info.is_change(), target=address_info.index
+        )
+        signals.wallet_signals[wallet.id].updated.emit(
+            UpdateFilter(
+                addresses=set([str(address_info.address) for address_info in revealed_address_infos]),
+                reason=UpdateFilterReason.NewAddressRevealed,
+            )
+        )
+    return revealed_address_infos
+
+
+def advance_tip_for_addresses(addresses: List[str], signals: Signals) -> List[bdk.AddressInfo]:
+    address_infos: List[bdk.AddressInfo] = []
+    for address in addresses:
+        if not address:
+            continue
+        wallet = get_wallet_of_address(address, signals)
+        if not wallet:
+            continue
+        if address_info := wallet.is_my_address_with_peek(address):
+            address_infos += advance_tip_to_address_info(
+                address_info=address_info, wallet=wallet, signals=signals
+            )
+    return address_infos

--- a/bitcoin_safe/gui/qt/ui_tx_creator.py
+++ b/bitcoin_safe/gui/qt/ui_tx_creator.py
@@ -301,13 +301,10 @@ class UITx_Creator(UITx_Base):
         fee_rate = self.fee_group.spin_fee_rate.value()
         fee_info = self.estimate_fee_info(fee_rate)
 
-        total_non_change_output_amount = sum(
-            [
-                r.amount
-                for r in self.recipients.recipients
-                if not (self.wallet.is_my_address(r.address) and self.wallet.is_change(r.address))
-            ]
+        total_non_change_output_amount = self._get_total_non_change_output_amount(
+            recipients=self.recipients.recipients, wallet=self.wallet
         )
+
         self.high_fee_warning_label.set_fee_to_send_ratio(
             fee_info=fee_info,
             total_non_change_output_amount=total_non_change_output_amount,

--- a/bitcoin_safe/gui/qt/ui_tx_viewer.py
+++ b/bitcoin_safe/gui/qt/ui_tx_viewer.py
@@ -88,7 +88,6 @@ from ...wallet import (
     TxConfirmationStatus,
     TxStatus,
     Wallet,
-    get_wallet_of_address,
     get_wallets,
     is_in_mempool,
 )
@@ -810,15 +809,9 @@ class UITx_Viewer(UITx_Base, ThreadingManager):
             self.high_fee_warning_label.setVisible(False)
             return
 
-        wallets: List[Wallet] = list(self.signals.get_wallets.emit().values())
-
-        total_non_change_output_amount = 0
-        for wallet in wallets:
-            for recipient in self.recipients.recipients:
-                if not recipient.address:
-                    continue
-                if not (wallet.is_my_address(recipient.address) and wallet.is_change(recipient.address)):
-                    total_non_change_output_amount += recipient.amount
+        total_non_change_output_amount = self._get_total_non_change_output_amount(
+            recipients=self.recipients.recipients
+        )
 
         self.high_fee_warning_label.set_fee_to_send_ratio(
             fee_info=self.fee_info,
@@ -1130,16 +1123,9 @@ class UITx_Viewer(UITx_Base, ThreadingManager):
             for txout in tx.output()
         ]
 
-        total_non_change_output_amount = 0
-
-        for address, value in out_flows:
-
-            wallet = get_wallet_of_address(address, self.signals)
-            if wallet and wallet.is_my_address(address) and wallet.is_change(address):
-                continue
-            else:
-                total_non_change_output_amount += value
-        return total_non_change_output_amount
+        return self._get_total_non_change_output_amount(
+            recipients=[Recipient(address=address, amount=value) for address, value in out_flows]
+        )
 
     def close(self):
         self.signal_tracker.disconnect_all()

--- a/bitcoin_safe/gui/qt/ui_tx_viewer.py
+++ b/bitcoin_safe/gui/qt/ui_tx_viewer.py
@@ -55,6 +55,7 @@ from bitcoin_safe.gui.qt.sankey_bitcoin import SankeyBitcoin
 from bitcoin_safe.gui.qt.tx_export import TxExport
 from bitcoin_safe.gui.qt.tx_signing_steps import TxSigningSteps
 from bitcoin_safe.gui.qt.tx_tools import TxTools
+from bitcoin_safe.gui.qt.tx_util import advance_tip_for_addresses
 from bitcoin_safe.gui.qt.ui_tx_base import UITx_Base
 from bitcoin_safe.gui.qt.warning_bars import LinkingWarningBar, PoisoningWarningBar
 from bitcoin_safe.keystore import KeyStore
@@ -927,6 +928,15 @@ class UITx_Viewer(UITx_Base, ThreadingManager):
             self.handle_cpfp(tx=tx, this_fee_info=fee_info, chain_position=chain_position)
 
         outputs: List[bdk.TxOut] = tx.output()
+        advance_tip_for_addresses(
+            addresses=[
+                robust_address_str_from_script(
+                    o.script_pubkey, network=self.network, on_error_return_hex=False
+                )
+                for o in outputs
+            ],
+            signals=self.signals,
+        )
 
         self.recipients.recipients = [
             Recipient(
@@ -1073,6 +1083,15 @@ class UITx_Viewer(UITx_Base, ThreadingManager):
         )
 
         outputs: List[bdk.TxOut] = psbt.extract_tx().output()
+        advance_tip_for_addresses(
+            addresses=[
+                robust_address_str_from_script(
+                    o.script_pubkey, network=self.network, on_error_return_hex=False
+                )
+                for o in outputs
+            ],
+            signals=self.signals,
+        )
 
         self.recipients.recipients = [
             Recipient(


### PR DESCRIPTION
it might be that of a loaded TX/PSBT the addresses (created by another wallet) are not revealed by Bitcoin Safe yet.   
Forward scanning (peek) solved this. 

- [x] Check if bdk actually detected this with [lookahead](https://docs.rs/bdk_wallet/latest/bdk_wallet/struct.CreateParams.html#method.lookahead) and I should refresh  the address cache after loading a tx/PSBT . It is not
- [x] Scan ahead already on wallet load (this makes it independent of the UI edit field)

- scans 1000 addresses (+1000 change) ahead to see if the address belongs to the wallet. If it does it reveals the addresses until the pasted address.
- refactor duplicate code of `total_non_change_output_amount`


## Required

- [x] `pre-commit install` before any commit. If pre-commit wasn't run for all commits, you can squash all commits   `git reset --soft $(git merge-base main HEAD) && git commit -m "squash"` and ensure the squashed commit is properly formatted
- [x] All commits must be signed. If some are not, you can squash all commits   `git reset --soft $(git merge-base main HEAD) && git commit -m "squash"` and ensure the squashed commit is signed
- [ ] Update all translations
 
## Optional

- [ ] Appropriate pytests were added
- [ ] Documentation is updated
