### PR TITLE
Remove threading for refresh_caches

### DIFF
--- a/bitcoin_safe/gui/qt/address_dialog.py
+++ b/bitcoin_safe/gui/qt/address_dialog.py
@@ -52,7 +52,6 @@ from bitcoin_safe.gui.qt.sign_message import SignMessage
 from bitcoin_safe.gui.qt.ui_tx.recipients import RecipientBox
 from bitcoin_safe.gui.qt.usb_register_multisig import USBValidateAddressWidget
 from bitcoin_safe.gui.qt.util import set_no_margins, svg_tools
-from bitcoin_safe.keystore import KeyStoreImporterTypes
 from bitcoin_safe.mempool_manager import MempoolManager
 from bitcoin_safe.typestubs import TypedPyQtSignal, TypedPyQtSignalNo
 
@@ -250,9 +249,7 @@ class AddressDialog(QWidget):
             else None
         )
         if self.tab_validate:
-            self.recipient_tabs.addTab(
-                self.tab_validate, svg_tools.get_QIcon(KeyStoreImporterTypes.hwi.icon_filename), ""
-            )
+            self.recipient_tabs.addTab(self.tab_validate, "")
 
         self.qr_code = QRAddress()
         self.qr_code.set_address(self.bdk_address)

--- a/bitcoin_safe/gui/qt/bitcoin_quick_receive.py
+++ b/bitcoin_safe/gui/qt/bitcoin_quick_receive.py
@@ -60,6 +60,7 @@ class BitcoinQuickReceive(
         self.signals_min = signals_min
         self.limit_to_categories = limit_to_categories
         self._pending_update = False
+        self._forced_update = False
 
         # fixed height
         self.setFixedHeight(220)

--- a/bitcoin_safe/gui/qt/main.py
+++ b/bitcoin_safe/gui/qt/main.py
@@ -850,7 +850,7 @@ class MainWindow(QMainWindow):
             "",
             partial(
                 webopen,
-                "https://yakihonne.com/users/npub1g9uhysae68vhvwwqel8v9enr9mg43rn4tpurs6a9g4jsrw6nl7lsplhs9v",
+                "https://yakihonne.com/profile/nprofile1qqsyz7tjgwuarktk88qvlnkzue3ja52c3e64s7pcdwj52egphdfll0cq9934g",
             ),
         )
 

--- a/bitcoin_safe/gui/qt/my_treeview.py
+++ b/bitcoin_safe/gui/qt/my_treeview.py
@@ -1391,6 +1391,7 @@ class MyTreeView(QTreeView, BaseSaveableClass, Generic[T]):
         # this MUST be after the selection,
         # such that on_selection_change is not triggered
         self._currently_updating = False
+        self._forced_update = False
 
         self.signal_finished_update.emit()
 

--- a/bitcoin_safe/gui/qt/wizard.py
+++ b/bitcoin_safe/gui/qt/wizard.py
@@ -94,7 +94,6 @@ from .util import (
     center_in_widget,
     create_button_box,
     generate_help_button,
-    get_icon_path,
     one_time_signal_connection,
     open_website,
     set_no_margins,
@@ -1279,7 +1278,7 @@ class LabelBackup(BaseTab):
         icon_basename = SyncTab.get_icon_basename(
             enabled=bool(self.refs.qt_wallet and self.refs.qt_wallet.sync_tab.enabled())
         )
-        self.icon.load(get_icon_path(icon_basename))
+        self.icon.setSvgContent(svg_content=svg_tools.get_svg_content(icon_basename=icon_basename))
         self.checkbox.setChecked(self.refs.qt_wallet.sync_tab.enabled() if self.refs.qt_wallet else False)
 
 

--- a/bitcoin_safe/network_config.py
+++ b/bitcoin_safe/network_config.py
@@ -112,8 +112,9 @@ def get_electrum_configs(network: bdk.Network) -> Dict[str, ElectrumConfig]:
             "electrum.blockstream.info": ElectrumConfig("electrum.blockstream.info:60002", True),  # testnet3
         },
         bdk.Network.TESTNET4: {
-            "default": ElectrumConfig("mempool.space:40002", True),  # Testnet4
-            "mempool.space": ElectrumConfig("mempool.space:40002", True),  # Testnet4
+            "default": ElectrumConfig("blackie.c3-soft.com:57010", True),
+            "blackie": ElectrumConfig("blackie.c3-soft.com:57010", True),
+            "mempool.space": ElectrumConfig("mempool.space:40002", True),
         },
         bdk.Network.SIGNET: {
             "default": ElectrumConfig("mempool.space:60602", True),

--- a/bitcoin_safe/wallet.py
+++ b/bitcoin_safe/wallet.py
@@ -1188,19 +1188,10 @@ class Wallet(BaseSaveableClass, CacheManager):
         return [a for a in output_addresses if a]
 
     @time_logger
-    def fill_commonly_used_caches(self) -> None:
-        # you have to repeat fetching new tx when you start watching new addresses
-        # And you can only start watching new addresses once you detected transactions on them.
-        # Thas why this fetching has to be done in a loop
+    def fill_commonly_used_caches_min(self) -> None:
         self.clear_cache()
-        addresses = self.get_addresses()
-        self.get_height()
-        self.bdkwallet.list_output()
-        self.get_dict_fulltxdetail()
-        self.get_all_txos_dict()
+        self.get_addresses()
         self.set_categories_of_used_addresses()
-        if addresses:
-            self.is_my_address_with_peek(addresses[-1])
 
     @instance_lru_cache()
     def get_txs(self) -> Dict[str, TransactionDetails]:

--- a/tools/release.py
+++ b/tools/release.py
@@ -62,15 +62,11 @@ def get_default_description(latest_tag: str):
 
 - 
 
+### Check out 
 
-### 🔋Batteries included🔋
-Lots of existing features were not mentioned above, so please check out:
-
-- [Why choose Bitcoin Safe?](https://bitcoin-safe.org/en/features/usps/)
 - www.bitcoin-safe.org
-- [Readme](https://github.com/andreasgriffin/bitcoin-safe?tab=readme-ov-file#bitcoin-safe) and [Comprehensive Feature List](https://github.com/andreasgriffin/bitcoin-safe?tab=readme-ov-file#comprehensive-feature-list)
-- Follow me on [nostr](https://yakihonne.com/users/npub1g9uhysae68vhvwwqel8v9enr9mg43rn4tpurs6a9g4jsrw6nl7lsplhs9v) or [X](https://x.com/BitcoinSafeOrg)
-
+- 🌍 Community forum: [chorus](https://chorus.community/group/34550%3Af8827954feef0092c8afec0be4cae544a9ed93dce9a365596e75b19aa05f0c84%3Abitcoin-safe-meiqbfki)
+- Follow on [nostr](https://yakihonne.com/profile/nprofile1qqsyz7tjgwuarktk88qvlnkzue3ja52c3e64s7pcdwj52egphdfll0cq9934g) or [X](https://x.com/BitcoinSafeOrg)
 
 ####  Verify signature
 


### PR DESCRIPTION
- `fill_commonly_used_caches`  could cause a qthread crash.  Now completely removed threading for `fill_commonly_used_caches` .  All updates seem to be below 1 sec. For `TxViewer`  now there is `maybe_defer_update` to prevent usefless updates for unseen tabs

## Required

- [x] `pre-commit install` before any commit. If pre-commit wasn't run for all commits, you can squash all commits   `git reset --soft $(git merge-base main HEAD) && git commit -m "squash"` and ensure the squashed commit is properly formatted
- [x] All commits must be signed. If some are not, you can squash all commits   `git reset --soft $(git merge-base main HEAD) && git commit -m "squash"` and ensure the squashed commit is signed
- [ ] Update all translations
 
## Optional

- [ ] Appropriate pytests were added
- [ ] Documentation is updated
