### PR TITLE
1 default category, and add manage categories to quickreceive

### DIFF
--- a/bitcoin_safe/gui/qt/bitcoin_quick_receive.py
+++ b/bitcoin_safe/gui/qt/bitcoin_quick_receive.py
@@ -54,7 +54,7 @@ class BitcoinQuickReceive(
         limit_to_categories=None,
         parent=None,
     ) -> None:
-        super().__init__(self.tr("Quick Receive"), parent=parent)
+        super().__init__("", parent=parent)
         self.wallet_signals = wallet_signals
         self.wallet = wallet
         self.signals_min = signals_min
@@ -64,6 +64,7 @@ class BitcoinQuickReceive(
 
         # fixed height
         self.setFixedHeight(220)
+        self.label_title.setVisible(False)
 
         # signals
         self.wallet_signals.updated.connect(self.update_content)

--- a/bitcoin_safe/gui/qt/category_manager/category_core.py
+++ b/bitcoin_safe/gui/qt/category_manager/category_core.py
@@ -155,7 +155,7 @@ class CategoryCore(QObject):
 
     @classmethod
     def get_default_categories(cls) -> List[str]:
-        return [translate("category", "KYC Exchange"), translate("category", "Private")]
+        return [translate("category", "Default")]
 
     def add_default_categories(self) -> None:
         for category in self.get_default_categories():

--- a/bitcoin_safe/gui/qt/sidebar/sidebar_tree.py
+++ b/bitcoin_safe/gui/qt/sidebar/sidebar_tree.py
@@ -55,6 +55,8 @@ from bitcoin_safe.gui.qt.qr_components.square_buttons import FlatSquareButton
 from bitcoin_safe.gui.qt.util import set_no_margins, set_translucent, svg_tools
 from bitcoin_safe.typestubs import TypedPyQtSignal
 
+from ..util import to_color_name
+
 logger = logging.getLogger(__name__)
 
 
@@ -127,19 +129,15 @@ class SidebarRow(QWidget):
         base = f"#{widget.objectName()}"
         css = ""
         if self.hover_color:
-            css += f"\n{base}:hover {{ background-color: {self._to_color_name(self.hover_color)}; }}"
+            css += f"\n{base}:hover {{ background-color: {to_color_name(self.hover_color)}; }}"
         if self.selected_color:
-            css += f'\n{base}[selected="true"] {{ background-color: {self._to_color_name(self.selected_color)}; }}'
+            css += f'\n{base}[selected="true"] {{ background-color: {to_color_name(self.selected_color)}; }}'
         if self.selected_hover_color:
-            css += f'\n{base}[selected="true"]:hover {{ background-color: {self._to_color_name(self.selected_hover_color)}; }}'
+            css += f'\n{base}[selected="true"]:hover {{ background-color: {to_color_name(self.selected_hover_color)}; }}'
         return css
 
     def style_widget(self, widget: QWidget):
         self.setStyleSheet(self.get_css(widget=widget))
-
-    @staticmethod
-    def _to_color_name(color: str | QPalette.ColorRole) -> str:
-        return QApplication.palette().color(color).name() if isinstance(color, QPalette.ColorRole) else color
 
     def _on_main_toggled(self, selected: bool) -> None:
         # Update dynamic property and repolish so QSS re-evaluates selectors

--- a/bitcoin_safe/gui/qt/util.py
+++ b/bitcoin_safe/gui/qt/util.py
@@ -1144,3 +1144,7 @@ def button_info(name: ButtonInfoType) -> ButtonInfo:
             ),
             icon_name="pen.svg",
         )
+
+
+def to_color_name(color: str | QPalette.ColorRole) -> str:
+    return QApplication.palette().color(color).name() if isinstance(color, QPalette.ColorRole) else color

--- a/bitcoin_safe/gui/qt/wizard.py
+++ b/bitcoin_safe/gui/qt/wizard.py
@@ -945,6 +945,13 @@ class ReceiveTest(BaseTab):
                 parent=widget,
                 signals_min=self.refs.qt_wallet.signals,
             )
+            self.quick_receive.signal_manage_categories_requested.connect(
+                self.refs.qt_wallet.category_manager.show
+            )
+            self.quick_receive.signal_add_category_requested.connect(
+                self.refs.qt_wallet.category_manager.add_category
+            )
+            self.quick_receive.set_manage_categories_enabled(True)
             self.quick_receive.setMaximumWidth(300)
             widget_layout.addWidget(self.quick_receive)
         else:

--- a/tests/gui/qt/test_setup_wallet.py
+++ b/tests/gui/qt/test_setup_wallet.py
@@ -361,9 +361,9 @@ def test_wizard(
                 box = qt_wallet.uitx_creator.recipients.get_recipient_group_boxes()[0]
                 shutter.save(main_window)
                 assert [recipient.address for recipient in qt_wallet.uitx_creator.recipients.recipients] == [
-                    "bcrt1qz07mxz0pm3mj4jhypc6llm5mtzkcdeu3pnw042"
+                    "bcrt1qmx7ke6j0amadeca65xqxpwh0utju5g3uka2sj5"
                 ]
-                assert box.address == "bcrt1qz07mxz0pm3mj4jhypc6llm5mtzkcdeu3pnw042"
+                assert box.address == "bcrt1qmx7ke6j0amadeca65xqxpwh0utju5g3uka2sj5"
                 assert (
                     box.recipient_widget.address_edit.input_field.palette()
                     .color(QtGui.QPalette.ColorRole.Base)
@@ -387,7 +387,7 @@ def test_wizard(
                 viewer = main_window.tab_wallets.currentNode().data
                 assert isinstance(viewer, UITx_Viewer)
                 assert [recipient.address for recipient in viewer.recipients.recipients] == [
-                    "bcrt1qz07mxz0pm3mj4jhypc6llm5mtzkcdeu3pnw042"
+                    "bcrt1qmx7ke6j0amadeca65xqxpwh0utju5g3uka2sj5"
                 ]
                 assert [recipient.label for recipient in viewer.recipients.recipients] == ["Send Test"]
                 assert [recipient.amount for recipient in viewer.recipients.recipients] == [999890]

--- a/tools/translation_handler.py
+++ b/tools/translation_handler.py
@@ -132,9 +132,9 @@ class TranslationHandler:
             f"""
 Translate all following lines   to the following languages
  {self.languages}
-Information context:  A bitcoin only bitcoin wallet.   So a term like "KYC Exchange"  means a trading place, that requires KYC. A wallet is a software that shows the balances on bitcoin addresses that belong to the user.  An address is a bitcoin address. 
+Information context:  A bitcoin only bitcoin wallet.   So a term like "Default" describes the fallback spending category that new wallets start with. A wallet is a software that shows the balances on bitcoin addresses that belong to the user.  An address is a bitcoin address.
 Formatting instructions:
-- no bullets points.  
+- no bullets points.
 - preserve the linebreaks of each line perfectly! keep the newline after each translated line.
 - leave the brackets {{}} and their content unchanged
 - group by language  (add 2 linebreaks after the language caption)


### PR DESCRIPTION
- 1 category by default  (otherwise it assigns all addresses to the 1 category and only the last unused address to other categories. That creates confusion for users when restoring a wallet. How were categories assigned?).  
-  adding a "Manage categories" button  in the top right of quick receive

<img width="989" height="216" alt="image" src="https://github.com/user-attachments/assets/2d133e37-1e64-4266-a026-184cdb45de53" />


## Required

- [x] `pre-commit install` before any commit. If pre-commit wasn't run for all commits, you can squash all commits   `git reset --soft $(git merge-base main HEAD) && git commit -m "squash"` and ensure the squashed commit is properly formatted
- [x] All commits must be signed. If some are not, you can squash all commits   `git reset --soft $(git merge-base main HEAD) && git commit -m "squash"` and ensure the squashed commit is signed
- [ ] Update all translations
 
## Optional

- [ ] Appropriate pytests were added
- [ ] Documentation is updated
