### PR TITLE
Fix wallet tab selection on restart

### DIFF
--- a/bitcoin_safe/gui/qt/qt_wallet.py
+++ b/bitcoin_safe/gui/qt/qt_wallet.py
@@ -243,6 +243,7 @@ class QTWallet(QtWalletBase, BaseSaveableClass):
             tutorial_index=tutorial_index,
             parent=parent,
         )
+        self.last_tab_title = last_tab_title
         self.mempool_manager = mempool_manager
         self.wallet = self.set_wallet(wallet)
         self.password = password
@@ -311,7 +312,6 @@ class QTWallet(QtWalletBase, BaseSaveableClass):
         self.update_status_visualization(self.sync_status)
 
         self.updateUi()
-        self.tabs.set_current_tab_by_text(last_tab_title)
         self.quick_receive.update_content(UpdateFilter(refresh_all=True))
 
         #### connect signals
@@ -497,6 +497,9 @@ class QTWallet(QtWalletBase, BaseSaveableClass):
     @property
     def wallet_signals(self) -> WalletSignals:
         return self.signals.wallet_signals[self.wallet.id]
+
+    def restore_last_selected_tab(self):
+        self.tabs.set_current_tab_by_text(self.last_tab_title)
 
     def on_updated(self, update_filter: UpdateFilter):
         address_infos = [


### PR DESCRIPTION
## Required

- [x] `pre-commit install` before any commit. If pre-commit wasn't run for all commits, you can squash all commits   `git reset --soft $(git merge-base main HEAD) && git commit -m "squash"` and ensure the squashed commit is properly formatted
- [x] All commits must be signed. If some are not, you can squash all commits   `git reset --soft $(git merge-base main HEAD) && git commit -m "squash"` and ensure the squashed commit is signed
- [ ] Update all translations
 
## Optional

- [ ] Appropriate pytests were added
- [ ] Documentation is updated
