### PR TITLE
Fix workflow tests to fail on test failiure

### DIFF
--- a/.github/workflows/build-and-test-mac.yml
+++ b/.github/workflows/build-and-test-mac.yml
@@ -163,6 +163,13 @@ jobs:
           echo "Found app at: $APP_PATH" | tee -a test_dmg.log
 
           # Launch the app.
+          LOG_DIR="$HOME/Library/Application Support/bitcoin_safe"
+
+          if [ -d "$LOG_DIR" ]; then
+            echo "Removing pre-existing bitcoin_safe logs under $LOG_DIR" | tee -a test_dmg.log
+            rm -f "$LOG_DIR"/bitcoin_safe.log* || true
+          fi
+
           echo "Launching app via open" | tee -a test_dmg.log
           open "$APP_PATH"
 
@@ -192,8 +199,9 @@ jobs:
 
       - name: Check for pyzbar log entry in bitcoin_safe.log
         run: |
-          echo "Checking bitcoin_safe.log for 'pyzbar could be loaded successfully'..." | tee -a test_dmg.log
-          if ! grep -q "pyzbar could be loaded successfully" "/Users/runner/Library/Application Support/bitcoin_safe/bitcoin_safe.log"; then
+          LOG_PATH="$HOME/Library/Application Support/bitcoin_safe/bitcoin_safe.log"
+          echo "Checking bitcoin_safe.log for 'pyzbar could be loaded successfully' at $LOG_PATH..." | tee -a test_dmg.log
+          if ! grep -q "pyzbar could be loaded successfully" "$LOG_PATH"; then
             echo "Error: 'pyzbar could be loaded successfully' not found in bitcoin_safe.log" | tee -a test_dmg.log
             exit 1
           fi

--- a/.github/workflows/build-appimage-and-test.yml
+++ b/.github/workflows/build-appimage-and-test.yml
@@ -231,6 +231,11 @@ jobs:
           APP_CMD=$(cat package_path.txt)
           echo "Launching $APP_CMD"
           LOG_FILE="run-${{ matrix.package }}.log"
+          LOG_DIR="$HOME/.config/bitcoin_safe"
+          if [ -d "$LOG_DIR" ]; then
+            echo "Removing pre-existing bitcoin_safe logs under $LOG_DIR"
+            rm -f "$LOG_DIR"/bitcoin_safe.log* || true
+          fi
           touch "$LOG_FILE"
           "$APP_CMD" >>"$LOG_FILE" 2>&1 &
           echo $! > app_launch.pid

--- a/.github/workflows/build-windows-and-test.yml
+++ b/.github/workflows/build-windows-and-test.yml
@@ -228,6 +228,14 @@ jobs:
           $expectedLogPath = Join-Path $env:LOCALAPPDATA 'bitcoin_safe\bitcoin_safe\bitcoin_safe.log'
           $resolvedLogPath = $null
 
+          $logDirectory = Split-Path $expectedLogPath -Parent
+          if (Test-Path $logDirectory) {
+            Get-ChildItem -Path $logDirectory -Filter 'bitcoin_safe.log*' -File -ErrorAction SilentlyContinue | ForEach-Object {
+              Write-Log "Removing pre-existing application log $($_.FullName)"
+              Remove-Item -Path $_.FullName -Force -ErrorAction SilentlyContinue
+            }
+          }
+
           try {
             Write-Log "Starting portable executable..."
             $process = Start-Process -FilePath $portableExe.FullName -WorkingDirectory $portableExe.DirectoryName -PassThru


### PR DESCRIPTION
- clears the logs

## Required

- [x] `pre-commit install` before any commit. If pre-commit wasn't run for all commits, you can squash all commits   `git reset --soft $(git merge-base main HEAD) && git commit -m "squash"` and ensure the squashed commit is properly formatted
- [x] All commits must be signed. If some are not, you can squash all commits   `git reset --soft $(git merge-base main HEAD) && git commit -m "squash"` and ensure the squashed commit is signed
- [ ] Update all translations
 
## Optional

- [ ] Appropriate pytests were added
- [ ] Documentation is updated
