### PR TITLE
Fix sync indicator

### DIFF
--- a/bitcoin_safe/gui/qt/wizard.py
+++ b/bitcoin_safe/gui/qt/wizard.py
@@ -1449,10 +1449,13 @@ class SendTest(BaseTab):
 
         self.widget_layout.addWidget(self.refs.qt_wallet.uitx_creator)
         self.refs.qt_wallet.uitx_creator.setVisible(True)
-        if self.refs.qt_wallet.sync_status in [SyncStatus.unknown, SyncStatus.unsynced]:
+        if self.refs.qt_wallet.wallet.client and self.refs.qt_wallet.wallet.client.sync_status in [
+            SyncStatus.unknown,
+            SyncStatus.unsynced,
+        ]:
             logger.debug(
                 f"Skipping tutorial callback  for send test, "
-                f"because {self.refs.qt_wallet.wallet.id} sync_status={self.refs.qt_wallet.sync_status}"
+                f"because {self.refs.qt_wallet.wallet.id} sync_status={self.refs.qt_wallet.wallet.client.sync_status}"
             )
             return
         logger.debug("tutorial callback")


### PR DESCRIPTION
- deduplicate variables
- update the qt elements only from  main thread (not async threads)
- Thanks to  @design-rrr  for discovering this bug



## Required

- [x] `pre-commit install` before any commit. If pre-commit wasn't run for all commits, you can squash all commits   `git reset --soft $(git merge-base main HEAD) && git commit -m "squash"` and ensure the squashed commit is properly formatted
- [x] All commits must be signed. If some are not, you can squash all commits   `git reset --soft $(git merge-base main HEAD) && git commit -m "squash"` and ensure the squashed commit is signed
- [ ] Update all translations
 
## Optional

- [ ] Appropriate pytests were added
- [ ] Documentation is updated
