### PR TITLE
Prevent downgrade of sync status if Info.PROGRESS

### DIFF
--- a/bitcoin_safe/client.py
+++ b/bitcoin_safe/client.py
@@ -103,7 +103,7 @@ class Client:
         """Handle log info and returns if the sync_status was changed ."""
         if isinstance(info, bdk.Info.PROGRESS):
             new_progress = info.filters_downloaded_percent / 100
-            if new_progress == 1 and self.sync_status == SyncStatus.synced:
+            if self.sync_status == SyncStatus.synced:
                 # do not downgrade the sync status, merely on a Info.PROGRESS
                 return False
             self.progress = min(self.MAX_PROGRESS_WHILE_SYNC, new_progress)


### PR DESCRIPTION
- fix bug in the sync status display

## Required

- [x] `pre-commit install` before any commit. If pre-commit wasn't run for all commits, you can squash all commits   `git reset --soft $(git merge-base main HEAD) && git commit -m "squash"` and ensure the squashed commit is properly formatted
- [x] All commits must be signed. If some are not, you can squash all commits   `git reset --soft $(git merge-base main HEAD) && git commit -m "squash"` and ensure the squashed commit is signed
- [ ] Update all translations
 
## Optional

- [ ] Appropriate pytests were added
- [ ] Documentation is updated
