### PR TITLE
Fix error handling when opening same wallet

### DIFF
--- a/bitcoin_safe/gui/qt/main.py
+++ b/bitcoin_safe/gui/qt/main.py
@@ -1763,6 +1763,14 @@ class MainWindow(QMainWindow):
                 return None, password
             return None, password  # type: ignore[unreachable]
 
+        if (_guess_wallet_id := Path(file_path).stem) in self.qt_wallets:
+            Message(
+                self.tr("A wallet with id {name} is already open. Please close it first.").format(
+                    name=_guess_wallet_id
+                )
+            )
+            return None
+
         qt_wallet, password = try_load(file_path=file_path)
         if not qt_wallet:
             return None
@@ -1770,14 +1778,6 @@ class MainWindow(QMainWindow):
         if qt_wallet and password:
             # successfuly load, then cache the password
             self.password_cache.set_password("wallet", password)
-
-        if qt_wallet.wallet.id in self.qt_wallets:
-            Message(
-                self.tr("A wallet with id {name} is already open. Please close it first.").format(
-                    name=qt_wallet.wallet.id
-                )
-            )
-            return None
 
         qt_wallet = self.add_qt_wallet(qt_wallet, file_path=file_path, password=password, focus=focus)
         QApplication.processEvents()


### PR DESCRIPTION
## Required

- [x] `pre-commit install` before any commit. If pre-commit wasn't run for all commits, you can squash all commits   `git reset --soft $(git merge-base main HEAD) && git commit -m "squash"` and ensure the squashed commit is properly formatted
- [x] All commits must be signed. If some are not, you can squash all commits   `git reset --soft $(git merge-base main HEAD) && git commit -m "squash"` and ensure the squashed commit is signed
- [ ] Update all translations
 
## Optional

- [ ] Appropriate pytests were added
- [ ] Documentation is updated
