### PR TITLE
Gap detection: default is no button

### DIFF
--- a/bitcoin_safe/gui/qt/qt_wallet.py
+++ b/bitcoin_safe/gui/qt/qt_wallet.py
@@ -1041,6 +1041,7 @@ class QTWallet(QtWalletBase, BaseSaveableClass):
                 title=self.tr("Gap limit may be too low"),
                 true_button=QMessageBox.StandardButton.Yes,
                 false_button=QMessageBox.StandardButton.No,
+                default_is_true_button=False,
             ):
                 new_wallet = self.wallet.clone_without_peristence()
                 new_wallet.set_gap(new_gap)

--- a/poetry.lock
+++ b/poetry.lock
@@ -370,7 +370,7 @@ resolved_reference = "27746420e536fb2ba48d83127fd57ca70579fb09"
 
 [[package]]
 name = "bitcoin-safe-lib"
-version = "1.0.2"
+version = "1.0.3"
 description = "Python tools and library"
 optional = false
 python-versions = ">=3.10,<3.13"
@@ -387,7 +387,7 @@ pyqt6 = "^6.9.0"
 type = "git"
 url = "https://github.com/andreasgriffin/bitcoin-safe-lib.git"
 reference = "main"
-resolved_reference = "d71473cc892d0e426b6b12cf925db6762e44826e"
+resolved_reference = "2a6737ab4e225c637583162e59c83de45228db02"
 
 [[package]]
 name = "bitcoin-usb"


### PR DESCRIPTION
## Required

- `pre-commit install` before any commit. If pre-commit wasn't run for all commits, you can squash all commits   `git reset --soft $(git merge-base main HEAD) && git commit -m "squash"` and ensure the squashed commit is properly formatted
- All commits must be signed. If some are not, you can squash all commits   `git reset --soft $(git merge-base main HEAD) && git commit -m "squash"` and ensure the squashed commit is signed
- [ ] UI/Design/Menu changes **were** tested on _macOS_, because _macOS_ creates endless problems.  Optionally attach a screenshot.
 
## Optional

- [ ] Update all translations
- [ ] Appropriate pytests were added
- [ ] Documentation is updated
