### PR TITLE
Initialize click_url for icon label

### DIFF
--- a/bitcoin_safe/gui/qt/icon_label.py
+++ b/bitcoin_safe/gui/qt/icon_label.py
@@ -69,6 +69,8 @@ class IconLabel(QWidget):
         self._layout = QHBoxLayout(self)
         set_no_margins(self._layout)
 
+        self.click_url: str | None = None
+
         # Icon Label
         self.icon_label = ClickableLabel()
         self.icon_label.setVisible(False)


### PR DESCRIPTION
- fixes bug:
```
- CRITICAL - [MainThread] - bitcoin_safe.gui.qt.util - AttributeError: 'IconLabel' object has no attribute 'click_url'
Traceback (most recent call last):
File "bitcoin_safe\gui\qt\icon_label.py", line 102, in on_icon_click
AttributeError: 'IconLabel' object has no attribute 'click_url'
```


## Required

- `pre-commit install` before any commit. If pre-commit wasn't run for all commits, you can squash all commits   `git reset --soft $(git merge-base main HEAD) && git commit -m "squash"` and ensure the squashed commit is properly formatted
- All commits must be signed. If some are not, you can squash all commits   `git reset --soft $(git merge-base main HEAD) && git commit -m "squash"` and ensure the squashed commit is signed
- [ ] UI/Design/Menu changes **were** tested on _macOS_, because _macOS_ creates endless problems.  Optionally attach a screenshot.
 
## Optional

- [ ] Update all translations
- [ ] Appropriate pytests were added
- [ ] Documentation is updated
- [ ] If this PR affects builds or install artifacts, set the `Build-Relevant` label to trigger build workflows
