### PR TITLE
Handle missing local chain changeset during serialization

### DIFF
--- a/bitcoin_safe/persister/changeset_converter.py
+++ b/bitcoin_safe/persister/changeset_converter.py
@@ -344,9 +344,7 @@ class ChangeSetConverter:
         try:
             local_chain_changeset = changeset.localchain_changeset()
         except SystemError:
-            logging.exception(
-                "Failed to read local chain changeset, defaulting to empty change set"
-            )
+            logging.exception("Failed to read local chain changeset, defaulting to empty change set")
             local_chain_changeset = bdk.LocalChainChangeSet(changes=[])
 
         out: dict[str, Any] = {


### PR DESCRIPTION
fixes:

```
CRITICAL - [MainThread] - bitcoin_safe.gui.qt.util - SystemError: error return without exception set
Traceback (most recent call last):
File "bitcoin_safe\gui\qt\qt_wallet.py", line 1547, in handle_client_update
File "bitcoin_safe\gui\qt\qt_wallet.py", line 1628, in on_update
File "bitcoin_safe\gui\qt\qt_wallet.py", line 886, in save
File "bitcoin_safe\gui\qt\qt_wallet.py", line 894, in save_to
File "bitcoin_safe_lib\util.py", line 124, in wrapper
File "bitcoin_safe\storage.py", line 282, in save
File "bitcoin_safe\storage.py", line 292, in dumps
File "json_init.py", line 238, in dumps
File "json\encoder.py", line 200, in encode
File "json\encoder.py", line 258, in iterencode
File "bitcoin_safe\storage.py", line 214, in general_serializer
File "bitcoin_safe\persister\serialize_persistence.py", line 81, in dump
File "bitcoin_safe\persister\changeset_converter.py", line 348, in to_dict
File "bdkpython\bdk.py", line 17505, in localchain_changeset
File "bdkpython\bdk.py", line 408, in lift
File "bdkpython\bdk.py", line 5521, in read
File "bdkpython\bdk.py", line 14717, in read
File "bdkpython\bdk.py", line 4661, in read
SystemError: error return without exception set
```


## Required

- `pre-commit install` before any commit. If pre-commit wasn't run for all commits, you can squash all commits   `git reset --soft $(git merge-base main HEAD) && git commit -m "squash"` and ensure the squashed commit is properly formatted
- All commits must be signed. If some are not, you can squash all commits   `git reset --soft $(git merge-base main HEAD) && git commit -m "squash"` and ensure the squashed commit is signed
- [ ] UI/Design/Menu changes **were** tested on _macOS_, because _macOS_ creates endless problems.  Optionally attach a screenshot.
 
## Optional

- [ ] Update all translations
- [ ] Appropriate pytests were added
- [ ] Documentation is updated
- [ ] If this PR affects builds or install artifacts, set the `Build-Relevant` label to trigger build workflows
