### PR TITLE
Better address formatting on Qr reading

### DIFF
--- a/bitcoin_safe/gui/qt/address_edit.py
+++ b/bitcoin_safe/gui/qt/address_edit.py
@@ -109,8 +109,8 @@ class AddressEdit(ButtonEdit):
     def _on_handle_input(self, data: Data) -> None:
         """On handle input."""
         if data.data_type == DataType.Bip21:
-            if data.data.get("address"):
-                self.setText(data.data.get("address"))
+            if address := data.data.get("address"):
+                self.setText(address)
             self.signal_bip21_input.emit(data)
 
     def set_allow_edit(self, allow_edit: bool):

--- a/bitcoin_safe/gui/qt/ui_tx/recipients.py
+++ b/bitcoin_safe/gui/qt/ui_tx/recipients.py
@@ -248,12 +248,17 @@ class RecipientWidget(QWidget):
     def on_address_bip21_input(self, data: Data) -> None:
         """On address bip21 input."""
         if data.data_type == DataType.Bip21:
-            if data.data.get("address"):
-                self.address_edit.address = data.data.get("address")
-            if data.data.get("amount"):
-                self.amount = data.data.get("amount")
-            if data.data.get("label"):
-                self.label_line_edit.set_label(data.data.get("label"))
+            if address := data.data.get("address"):
+                try:
+                    # overwrite address with correct formatting if possible
+                    address = str(bdk.Address(address, self.address_edit.network))
+                except Exception:
+                    pass
+                self.address_edit.address = address
+            if amount := data.data.get("amount"):
+                self.amount = amount
+            if label := data.data.get("label"):
+                self.label_line_edit.set_label(label)
 
     def updateUi(self) -> None:
         """UpdateUi."""


### PR DESCRIPTION
- standardizes  the address from bip32 if possible  by putting it through bdk.Address


## Required

- `pre-commit install` before any commit. If pre-commit wasn't run for all commits, you can squash all commits   `git reset --soft $(git merge-base main HEAD) && git commit -m "squash"` and ensure the squashed commit is properly formatted
- All commits must be signed. If some are not, you can squash all commits   `git reset --soft $(git merge-base main HEAD) && git commit -m "squash"` and ensure the squashed commit is signed
- [ ] UI/Design/Menu changes **were** tested on _macOS_, because _macOS_ creates endless problems.  Optionally attach a screenshot.
 
## Optional

- [ ] Update all translations
- [ ] Appropriate pytests were added
- [ ] Documentation is updated
- [ ] If this PR affects builds or install artifacts, set the `Build-Relevant` label to trigger build workflows
