### PR TITLE
Write and cleanup pdfs to cache dir

### DIFF
--- a/bitcoin_safe/pdf_labels.py
+++ b/bitcoin_safe/pdf_labels.py
@@ -28,9 +28,6 @@
 
 from __future__ import annotations
 
-import logging
-import os
-from pathlib import Path
 from typing import Any
 
 from reportlab.lib import colors
@@ -40,9 +37,7 @@ from reportlab.lib.units import cm
 from reportlab.platypus import KeepInFrame, Paragraph, Spacer, Table, TableStyle
 
 from bitcoin_safe.i18n import translate
-from bitcoin_safe.pdfrecovery import BasePDF, white_space
-
-logger = logging.getLogger(__name__)
+from bitcoin_safe.pdfrecovery import BasePDF, white_space, write_and_open_temp_pdf
 
 
 class PDFLabels(BasePDF):
@@ -166,12 +161,9 @@ def make_and_open_labels_pdf(wallet_id: str, label_pairs: list[tuple[str, str]],
     pdf_labels = PDFLabels(lang_code=lang_code)
     pdf_labels.add_labels(wallet_id=wallet_id, label_pairs=label_pairs)
 
-    filename = (
-        translate("pdf", "Hardware signer labels for {id}", no_translate=pdf_labels.no_translate).format(
-            id=wallet_id
-        )
-        + ".pdf"
-    )
-    temp_file = os.path.join(Path.home(), filename)
-    pdf_labels.save_pdf(temp_file)
-    pdf_labels.open_pdf(temp_file)
+    filename = translate(
+        "pdf",
+        "Hardware signer labels for {id}",
+        no_translate=pdf_labels.no_translate,
+    ).format(id=wallet_id)
+    write_and_open_temp_pdf(pdf_labels, filename)

--- a/bitcoin_safe/pdf_statement.py
+++ b/bitcoin_safe/pdf_statement.py
@@ -30,8 +30,6 @@ from __future__ import annotations
 
 import datetime
 import logging
-import os
-from pathlib import Path
 from typing import Any
 
 import bdkpython as bdk
@@ -46,7 +44,7 @@ from reportlab.pdfgen.canvas import Canvas
 from reportlab.platypus import PageBreak, Paragraph, Table, TableStyle
 
 from bitcoin_safe.i18n import translate
-from bitcoin_safe.pdfrecovery import BasePDF, pilimage_to_reportlab, white_space
+from bitcoin_safe.pdfrecovery import BasePDF, pilimage_to_reportlab, white_space, write_and_open_temp_pdf
 
 from .wallet import Wallet
 
@@ -359,6 +357,4 @@ def make_and_open_pdf_statement(wallet: Wallet, lang_code: str, label_sync_nsec:
         label_sync_nsec=label_sync_nsec,
     )
 
-    temp_file = os.path.join(Path.home(), f"{file_title}.pdf")
-    pdf_statement.save_pdf(temp_file)
-    pdf_statement.open_pdf(temp_file)
+    write_and_open_temp_pdf(pdf_statement, file_title)

--- a/tests/gui/qt/test_setup_wallet.py
+++ b/tests/gui/qt/test_setup_wallet.py
@@ -30,12 +30,12 @@ from __future__ import annotations
 
 import inspect
 import logging
-import os
 from datetime import datetime
 from pathlib import Path
 from unittest.mock import patch
 
 import bdkpython as bdk
+import platformdirs
 import pytest
 from bitcoin_safe_lib.gui.qt.satoshis import Satoshis
 from bitcoin_safe_lib.util import insert_invisible_spaces_for_wordwrap
@@ -321,10 +321,12 @@ def test_wizard(
                     step.custom_yes_button.click()
                     mock_open.assert_called_once()
 
-                    temp_file = os.path.join(Path.home(), f"Seed backup of {wallet_name}.pdf")
-                    assert Path(temp_file).exists()
-                    # remove the file again
-                    Path(temp_file).unlink()
+                    cache_dir = Path(platformdirs.user_cache_dir("bitcoin_safe"))
+                    prefix = f"Seed backup of {wallet_name}".replace(" ", "_")
+                    temp_files = list(cache_dir.glob(f"{prefix}-*.pdf"))
+                    assert temp_files
+                    for temp_file in temp_files:
+                        temp_file.unlink()
 
             page_backup()
 

--- a/tests/gui/qt/test_wallet_features.py
+++ b/tests/gui/qt/test_wallet_features.py
@@ -30,7 +30,6 @@ from __future__ import annotations
 
 import inspect
 import logging
-import os
 import platform
 import tempfile
 from datetime import datetime
@@ -38,6 +37,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 import bdkpython as bdk
+import platformdirs
 import pytest
 from bitcoin_qr_tools.gui.bitcoin_video_widget import BitcoinVideoWidget
 from bitcoin_usb.address_types import AddressTypes
@@ -293,10 +293,12 @@ def test_wallet_features_multisig(
 
                     mock_open.assert_called_once()
 
-                    temp_file = os.path.join(Path.home(), f"Seed backup of {wallet_name}.pdf")
-                    assert Path(temp_file).exists()
-                    # remove the file again
-                    Path(temp_file).unlink()
+                    cache_dir = Path(platformdirs.user_cache_dir("bitcoin_safe"))
+                    prefix = f"Seed backup of {wallet_name}".replace(" ", "_")
+                    temp_files = list(cache_dir.glob(f"{prefix}-*.pdf"))
+                    assert temp_files
+                    for temp_file in temp_files:
+                        temp_file.unlink()
 
             menu_action_export_pdf()
 


### PR DESCRIPTION
write pdfs to cache dir and cleanup on exit

Tested on
- [x] Kubuntu
- [x] Mint
- [x] Mac
- [x] Windows


## Required

- `pre-commit install` before any commit. If pre-commit wasn't run for all commits, you can squash all commits   `git reset --soft $(git merge-base main HEAD) && git commit -m "squash"` and ensure the squashed commit is properly formatted
- All commits must be signed. If some are not, you can squash all commits   `git reset --soft $(git merge-base main HEAD) && git commit -m "squash"` and ensure the squashed commit is signed
- [ ] UI/Design/Menu changes **were** tested on _macOS_, because _macOS_ creates endless problems.  Optionally attach a screenshot.
 
## Optional

- [ ] Update all translations
- [ ] Appropriate pytests were added
- [ ] Documentation is updated
- [ ] If this PR affects builds or install artifacts, set the `Build-Relevant` label to trigger build workflows
