### PR TITLE
Pytest: skip test on network failiure

### DIFF
--- a/tests/non_gui/test_signature_manager.py
+++ b/tests/non_gui/test_signature_manager.py
@@ -68,9 +68,9 @@ def test_download_manifest_and_verify_wrong_signature() -> None:
         logger.debug(f"tempdir {tempdir}")
         try:
             sig_filename = manager.get_signature_from_web(Path(tempdir) / "Sparrow-1.8.4-x86_64.dmg")
+            assert sig_filename
         except Exception as exc:
             pytest.skip(f"Skipping manifest download: {exc}")
-        assert sig_filename
         logger.debug(f"sig_filename {sig_filename}")
 
         manifest_file = Path(tempdir) / "sparrow-1.8.4-manifest.txt"


### PR DESCRIPTION
on network failiures skip a test

## Required

- `pre-commit install` before any commit. If pre-commit wasn't run for all commits, you can squash all commits   `git reset --soft $(git merge-base main HEAD) && git commit -m "squash"` and ensure the squashed commit is properly formatted
- All commits must be signed. If some are not, you can squash all commits   `git reset --soft $(git merge-base main HEAD) && git commit -m "squash"` and ensure the squashed commit is signed
- [ ] UI/Design/Menu changes **were** tested on _macOS_, because _macOS_ creates endless problems.  Optionally attach a screenshot.
 
## Optional

- [ ] Update all translations
- [ ] Appropriate pytests were added
- [ ] Documentation is updated
- [ ] If this PR affects builds or install artifacts, set the `Build-Relevant` label to trigger build workflows
