### PR TITLE
pytest: Remove menu_action_check_update in github windows

### DIFF
--- a/tests/gui/qt/helpers.py
+++ b/tests/gui/qt/helpers.py
@@ -539,3 +539,7 @@ class CheckedDeletionContext:
             # runt eh line below separately
             # len(get_cell_referrers(self))
         ##### for_debug_only
+
+
+def running_on_github() -> bool:
+    return os.getenv("GITHUB_ACTIONS") == "true"

--- a/tests/gui/qt/test_wallet_features.py
+++ b/tests/gui/qt/test_wallet_features.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 import inspect
 import logging
 import os
+import platform
 import tempfile
 from datetime import datetime
 from pathlib import Path
@@ -64,6 +65,7 @@ from .helpers import (
     close_wallet,
     do_modal_click,
     main_window_context,
+    running_on_github,
     save_wallet,
 )
 
@@ -463,6 +465,10 @@ def test_wallet_features_multisig(
 
             def menu_action_check_update() -> None:
                 """Menu action check update."""
+                if platform.system() == "Windows" and running_on_github():
+                    # github windows network is very flaky
+                    return
+
                 main_window.menu_action_check_update.trigger()
                 shutter.save(main_window)
                 assert main_window.update_notification_bar.isVisible()


### PR DESCRIPTION
## Required

- `pre-commit install` before any commit. If pre-commit wasn't run for all commits, you can squash all commits   `git reset --soft $(git merge-base main HEAD) && git commit -m "squash"` and ensure the squashed commit is properly formatted
- All commits must be signed. If some are not, you can squash all commits   `git reset --soft $(git merge-base main HEAD) && git commit -m "squash"` and ensure the squashed commit is signed
- [ ] UI/Design/Menu changes **were** tested on _macOS_, because _macOS_ creates endless problems.  Optionally attach a screenshot.
 
## Optional

- [ ] Update all translations
- [ ] Appropriate pytests were added
- [ ] Documentation is updated
- [ ] If this PR affects builds or install artifacts, set the `Build-Relevant` label to trigger build workflows
