### PR TITLE
Pytest: add waiting after a failed condition check

### DIFF
--- a/tests/util.py
+++ b/tests/util.py
@@ -104,11 +104,15 @@ def wait_for_sync(
     timeout: float = 10_000,
 ):
     def condition() -> bool:
-        return bool(
+        res = bool(
             wallet.get_balance().total >= minimum_funds
             and (not txid or wallet.get_tx(txid))
             and len(wallet.bdkwallet.transactions()) >= tx_count
         )
+        if not res:
+            QCoreApplication.processEvents()
+            qtbot.wait(200)
+        return res
 
     def info_message():
         logger.info(f"{wallet.get_balance().total=}")
@@ -125,7 +129,6 @@ def wait_for_sync(
         # cbf node syncronization happens without any triggering in the background
         # we just have to wait
         try:
-            QCoreApplication.processEvents()
             qtbot.waitUntil(condition, timeout=int(timeout))
         except Exception:
             raise


### PR DESCRIPTION
- hopefully fixes the windows mining sync problem

## Required

- `pre-commit install` before any commit. If pre-commit wasn't run for all commits, you can squash all commits   `git reset --soft $(git merge-base main HEAD) && git commit -m "squash"` and ensure the squashed commit is properly formatted
- All commits must be signed. If some are not, you can squash all commits   `git reset --soft $(git merge-base main HEAD) && git commit -m "squash"` and ensure the squashed commit is signed
- [ ] UI/Design/Menu changes **were** tested on _macOS_, because _macOS_ creates endless problems.  Optionally attach a screenshot.
 
## Optional

- [ ] Update all translations
- [ ] Appropriate pytests were added
- [ ] Documentation is updated
- [ ] If this PR affects builds or install artifacts, set the `Build-Relevant` label to trigger build workflows
