### PR TITLE
Workflow:  improved build all

### DIFF
--- a/.github/workflows/build-windows-and-test.yml
+++ b/.github/workflows/build-windows-and-test.yml
@@ -13,6 +13,11 @@ on:
       signing-policy-slug:
         description: 'signing-policy-slug  ("" for no signing, "test-signing", "release-signing" for valid signing)'
         required: false
+        type: choice
+        options:
+          - ''
+          - test-signing
+          - release-signing
         default: ''
       skip_build_and_test_release_tag:
         description: 'Release tag to download prebuilt Windows artifacts instead of building (leave empty to build)'
@@ -20,6 +25,18 @@ on:
         default: ''
         type: string
   workflow_call:
+    inputs:
+      commitHash:
+        required: false
+        type: string
+      signing-policy-slug:
+        required: false
+        type: string
+        default: ''
+      skip_build_and_test_release_tag:
+        required: false
+        type: string
+        default: ''
 
 jobs:
   build:
@@ -111,7 +128,7 @@ jobs:
 
       - name: 'signing with ${{ github.event.inputs.signing-policy-slug }}'
         id: signpath-io
-        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.skip_build_and_test_release_tag == '' && github.event.inputs.signing-policy-slug != '' }}
+        if: ${{ github.event.inputs.skip_build_and_test_release_tag == '' && github.event.inputs.signing-policy-slug != '' }}
         uses: signpath/github-action-submit-signing-request@v1.1
         with:
           api-token: '${{ secrets.SIGNPATH_API_TOKEN }}'
@@ -124,7 +141,7 @@ jobs:
           output-artifact-directory: 'signpath-signed'
 
       - name: Upload Signed EXE Files from signpath-signed/
-        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.skip_build_and_test_release_tag == '' && github.event.inputs.signing-policy-slug != '' }}
+        if: ${{ github.event.inputs.skip_build_and_test_release_tag == '' && github.event.inputs.signing-policy-slug != '' }}
         id: upload-signed-artifact
         uses: actions/upload-artifact@v4
         with:
@@ -133,7 +150,7 @@ jobs:
 
 
       - name: Compare signed and unsigned files
-        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.skip_build_and_test_release_tag == '' && github.event.inputs.signing-policy-slug != '' }}
+        if: ${{ github.event.inputs.skip_build_and_test_release_tag == '' && github.event.inputs.signing-policy-slug != '' }}
         run: |
           tools/build-wine/verify_signed_executables.sh dist signpath-signed portable setup
 
@@ -142,21 +159,21 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Download signed portable artifact
-        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.skip_build_and_test_release_tag == '' && github.event.inputs.signing-policy-slug != '' }}
+        if: ${{ github.event.inputs.skip_build_and_test_release_tag == '' && github.event.inputs.signing-policy-slug != '' }}
         uses: actions/download-artifact@v4
         with:
           name: signpath-signed
           path: artifacts
 
       - name: Download unsigned portable artifact
-        if: ${{ github.event_name != 'workflow_dispatch' || (github.event.inputs.skip_build_and_test_release_tag == '' && github.event.inputs.signing-policy-slug == '') }}
+        if: ${{ github.event.inputs.skip_build_and_test_release_tag == '' && github.event.inputs.signing-policy-slug == '' }}
         uses: actions/download-artifact@v4
         with:
           name: dist
           path: artifacts
 
       - name: Download release artifacts
-        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.skip_build_and_test_release_tag != '' }}
+        if: ${{ github.event.inputs.skip_build_and_test_release_tag != '' }}
         env:
           GH_TOKEN: ${{ github.token }}
         shell: bash
@@ -175,7 +192,7 @@ jobs:
           done
 
       - name: Verify downloaded Windows artifacts
-        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.skip_build_and_test_release_tag != '' }}
+        if: ${{ github.event.inputs.skip_build_and_test_release_tag != '' }}
         shell: bash
         run: |
           set -euo pipefail

--- a/.github/workflows/run_all_builds.yml
+++ b/.github/workflows/run_all_builds.yml
@@ -4,6 +4,15 @@ permissions:
 
 on:
   workflow_dispatch:
+    inputs:
+      signing-policy-slug:
+        description: 'signing-policy-slug  ("" for no signing, "test-signing", "release-signing" for valid signing)'
+        type: choice
+        options:
+          - ''
+          - test-signing
+          - release-signing
+        default: ''
   pull_request:
     types:
       - opened
@@ -26,4 +35,6 @@ jobs:
   windows:
     if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'Build-Relevant')) }}
     uses: ./.github/workflows/build-windows-and-test.yml
+    with:
+      signing-policy-slug: ${{ github.event.inputs.signing-policy-slug || '' }}
     secrets: inherit


### PR DESCRIPTION
- allow choosing `signing-policy-slug` in  `run_all_builds.yml`


## Required

- `pre-commit install` before any commit. If pre-commit wasn't run for all commits, you can squash all commits   `git reset --soft $(git merge-base main HEAD) && git commit -m "squash"` and ensure the squashed commit is properly formatted
- All commits must be signed. If some are not, you can squash all commits   `git reset --soft $(git merge-base main HEAD) && git commit -m "squash"` and ensure the squashed commit is signed
- [ ] UI/Design/Menu changes **were** tested on _macOS_, because _macOS_ creates endless problems.  Optionally attach a screenshot.
 
## Optional

- [ ] Update all translations
- [ ] Appropriate pytests were added
- [ ] Documentation is updated
- [ ] If this PR affects builds or install artifacts, set the `Build-Relevant` label to trigger build workflows
