### PR TITLE
Txviewer: Fix edit of rbf PSBT

### DIFF
--- a/bitcoin_safe/gui/qt/tx_tools.py
+++ b/bitcoin_safe/gui/qt/tx_tools.py
@@ -101,6 +101,17 @@ class TxTools:
         return True
 
     @classmethod
+    def add_replace_tx_to_txuiinfos(
+        cls,
+        replace_tx: bdk.Transaction | None,
+        txinfos: TxUiInfos,
+    ):
+        if not GENERAL_RBF_AVAILABLE and replace_tx:
+            txinfos.utxos_read_only = True
+            txinfos.recipient_read_only = True
+            txinfos.replace_tx = replace_tx
+
+    @classmethod
     def edit_tx(
         cls,
         replace_tx: TransactionDetails | None,
@@ -115,10 +126,8 @@ class TxTools:
             # cannot be done safely
             return
 
-        if not GENERAL_RBF_AVAILABLE and replace_tx:
-            txinfos.utxos_read_only = True
-            txinfos.recipient_read_only = True
-            txinfos.replace_tx = replace_tx.transaction
+        if replace_tx:
+            cls.add_replace_tx_to_txuiinfos(replace_tx=replace_tx.transaction, txinfos=txinfos)
 
         txinfos.hide_UTXO_selection = False
         wallet_functions.signals.open_tx_like.emit(txinfos)


### PR DESCRIPTION
- moving from txcreator rbf tx, to txviewer the rbf replace_tx is lost.  this pr recovers the info if there is just 1 tx to be replaced

## Required

- `pre-commit install` before any commit. If pre-commit wasn't run for all commits, you can squash all commits   `git reset --soft $(git merge-base main HEAD) && git commit -m "squash"` and ensure the squashed commit is properly formatted
- All commits must be signed. If some are not, you can squash all commits   `git reset --soft $(git merge-base main HEAD) && git commit -m "squash"` and ensure the squashed commit is signed
- [ ] UI/Design/Menu changes **were** tested on _macOS_, because _macOS_ creates endless problems.  Optionally attach a screenshot.
 
## Optional

- [ ] Update all translations
- [ ] Appropriate pytests were added
- [ ] Documentation is updated
- [ ] If this PR affects builds or install artifacts, set the `Build-Relevant` label to trigger build workflows
