### PR TITLE
pytest: Improve bitcoin-cli reliability and error visibility in tests

### DIFF
--- a/tests/gui/qt/helpers.py
+++ b/tests/gui/qt/helpers.py
@@ -71,6 +71,7 @@ from bitcoin_safe.gui.qt.keystore_ui import SignerUI
 from bitcoin_safe.gui.qt.main import MainWindow
 from bitcoin_safe.gui.qt.qt_wallet import QTWallet
 from bitcoin_safe.gui.qt.ui_tx.ui_tx_viewer import UITx_Viewer
+from bitcoin_safe.wallet import TxStatus
 
 from ...faucet import Faucet
 from ...util import wait_for_sync
@@ -224,7 +225,14 @@ def broadcast_tx(qtbot: QtBot, shutter: Shutter, viewer: UITx_Viewer, qt_wallet:
 
     viewer.button_send.click()
     if isinstance((tx := viewer.data.data), bdk.Transaction):
-        qtbot.waitUntil(lambda: bool(qt_wallet.wallet.get_tx(str(tx.compute_txid()))), timeout=40_000)
+        txid = str(tx.compute_txid())
+
+        def is_in_mempool():
+            QApplication.processEvents()
+            qtbot.wait(100)  # to allow the ui to update
+            return TxStatus.from_wallet(txid=txid, wallet=qt_wallet.wallet).is_in_mempool()
+
+        qtbot.waitUntil(is_in_mempool, timeout=40_000)
         qtbot.wait(1000)  # to allow the ui to update
 
     shutter.save(viewer)


### PR DESCRIPTION
- fix the flakiness of pytest faucet
- tighten the "was broadcasted" check

## Required

- `pre-commit install` before any commit. If pre-commit wasn't run for all commits, you can squash all commits   `git reset --soft $(git merge-base main HEAD) && git commit -m "squash"` and ensure the squashed commit is properly formatted
- All commits must be signed. If some are not, you can squash all commits   `git reset --soft $(git merge-base main HEAD) && git commit -m "squash"` and ensure the squashed commit is signed
- [ ] UI/Design/Menu changes **were** tested on _macOS_, because _macOS_ creates endless problems.  Optionally attach a screenshot.
 
## Optional

- [ ] Update all translations
- [ ] Appropriate pytests were added
- [ ] Documentation is updated
- [ ] If this PR affects builds or install artifacts, set the `Build-Relevant` label to trigger build workflows
