### PR TITLE
UI Fix:  Prevent shrinking of settings window below minimum size hint

### DIFF
--- a/bitcoin_safe/gui/qt/network_settings/main.py
+++ b/bitcoin_safe/gui/qt/network_settings/main.py
@@ -48,6 +48,7 @@ from PyQt6.QtWidgets import (
     QGroupBox,
     QHBoxLayout,
     QLabel,
+    QLayout,
     QPushButton,
     QSizePolicy,
     QSpinBox,
@@ -183,6 +184,8 @@ class NetworkSettingsUI(QWidget):
         self.signals = signals
         self.network_configs = network_configs
         self._layout = QVBoxLayout(self)
+        # Prevent shrinking below the natural size of contained widgets without hard-coded dimensions
+        self._layout.setSizeConstraint(QLayout.SizeConstraint.SetMinimumSize)
 
         self.setWindowIcon(svg_tools.get_QIcon("logo.svg"))
         self.network_combobox = QComboBox(self)

--- a/bitcoin_safe/gui/qt/settings.py
+++ b/bitcoin_safe/gui/qt/settings.py
@@ -72,6 +72,7 @@ class Settings(QTabWidget):
         )
         self.addTab(self.network_settings_ui, "")
         self.network_settings_ui.signal_cancel.connect(self.close)
+        self.currentChanged.connect(self._apply_minimum_size_hint)
 
         # category manager(s)
         # self.category_tab=QWidget()
@@ -119,6 +120,7 @@ class Settings(QTabWidget):
         self.setTabText(self.indexOf(self.langauge_ui), self.tr("General"))
         self.setTabText(self.indexOf(self.about_tab), self.tr("About"))
         # self.setTabText(self.indexOf(self.category_tab), self.tr("Category Manager"))
+        self._apply_minimum_size_hint()
 
     def keyPressEvent(self, a0: QKeyEvent | None):
         # Check if the pressed key is 'Esc'
@@ -132,9 +134,14 @@ class Settings(QTabWidget):
     def showEvent(self, a0: QShowEvent | None) -> None:
         super().showEvent(a0)
         center_on_screen(self)
+        self._apply_minimum_size_hint()
 
     def open_about_tab(self) -> None:
         """Open the About tab and focus the settings window."""
         self.setCurrentWidget(self.about_tab)
         self.show()
         self.raise_()
+
+    def _apply_minimum_size_hint(self) -> None:
+        """Use Qt's calculated minimum size to prevent over-shrinking."""
+        self.setMinimumSize(self.minimumSizeHint())


### PR DESCRIPTION
- Prevent shrinking of settings window below minimum size hint


## Required

- `pre-commit install` before any commit. If pre-commit wasn't run for all commits, you can squash all commits   `git reset --soft $(git merge-base main HEAD) && git commit -m "squash"` and ensure the squashed commit is properly formatted
- All commits must be signed. If some are not, you can squash all commits   `git reset --soft $(git merge-base main HEAD) && git commit -m "squash"` and ensure the squashed commit is signed
- [ ] UI/Design/Menu changes **were** tested on _macOS_, because _macOS_ creates endless problems.  Optionally attach a screenshot.
 
## Optional

- [ ] Update all translations
- [ ] Appropriate pytests were added
- [ ] Documentation is updated
- [ ] If this PR affects builds or install artifacts, set the `Build-Relevant` label to trigger build workflows
