### PR TITLE
Bug fix:  setting the Bitcoin symbol combobox

### DIFF
--- a/bitcoin_safe/gui/qt/interface_settings_ui.py
+++ b/bitcoin_safe/gui/qt/interface_settings_ui.py
@@ -80,7 +80,7 @@ class InterfaceSettingsUi(QWidget):
         self.bitcoin_symbol_combo = QComboBox(self)
         self.bitcoin_symbol_combo.addItem(BitcoinSymbol.ISO.value, BitcoinSymbol.ISO)
         self.bitcoin_symbol_combo.addItem(BitcoinSymbol.UNICODE.value, BitcoinSymbol.UNICODE)
-        idx = self.bitcoin_symbol_combo.findData(self.config.bitcoin_symbol.value)
+        idx = self.bitcoin_symbol_combo.findData(self.config.bitcoin_symbol)
         self.bitcoin_symbol_combo.setCurrentIndex(idx if idx >= 0 else 0)
 
         # 3) Layout


### PR DESCRIPTION
## Required

- `pre-commit install` before any commit. If pre-commit wasn't run for all commits, you can squash all commits   `git reset --soft $(git merge-base main HEAD) && git commit -m "squash"` and ensure the squashed commit is properly formatted
- All commits must be signed. If some are not, you can squash all commits   `git reset --soft $(git merge-base main HEAD) && git commit -m "squash"` and ensure the squashed commit is signed
- [ ] UI/Design/Menu changes **were** tested on _macOS_, because _macOS_ creates endless problems.  Optionally attach a screenshot.
 
## Optional

- [ ] Update all translations
- [ ] Appropriate pytests were added
- [ ] Documentation is updated
- [ ] If this PR affects builds or install artifacts, set the `Build-Relevant` label to trigger build workflows
