### PR TITLE
Chore: make weblate workflow use verified bot commit

### DIFF
--- a/.github/workflows/weblate-correct.yml
+++ b/.github/workflows/weblate-correct.yml
@@ -46,26 +46,18 @@ jobs:
       - name: Run "Weblate correct"
         run: poetry run python tools/build.py --weblate_correct
 
-      - name: Commit changes
+      - name: Create verified commit via API
         id: commit
-        run: |
-          if git diff --quiet --ignore-submodules HEAD; then
-            echo "changed=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add .
-          git commit -m "chore: run Weblate correct"
-          echo "changed=true" >> "$GITHUB_OUTPUT"
-
-      - name: Push changes
-        if: steps.commit.outputs.changed == 'true'
-        run: |
-          git push origin "HEAD:${{ github.event.pull_request.head.ref }}"
+        uses: iarekylew00t/verified-bot-commit@v2
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          message: "chore: run Weblate correct"
+          files: |
+            **
+          if-no-commit: notice
 
       - name: Comment on PR
-        if: steps.commit.outputs.changed == 'true'
+        if: steps.commit.outputs.commit != ''
         uses: actions/github-script@v7
         with:
           script: |


### PR DESCRIPTION
## Required

- `pre-commit install` before any commit. If pre-commit wasn't run for all commits, you can squash all commits   `git reset --soft $(git merge-base main HEAD) && git commit -m "squash"` and ensure the squashed commit is properly formatted
- All commits must be signed. If some are not, you can squash all commits   `git reset --soft $(git merge-base main HEAD) && git commit -m "squash"` and ensure the squashed commit is signed
- [ ] UI/Design/Menu changes **were** tested on _macOS_, because _macOS_ creates endless problems.  Optionally attach a screenshot.
 
## Optional

- [ ] Update all translations
- [ ] Appropriate pytests were added
- [ ] Documentation is updated
- [ ] If this PR affects builds or install artifacts, set the `Build-Relevant` label to trigger build workflows
