### PR TITLE
Workflow: Use github-commit-sign for Weblate workflow

### DIFF
--- a/.github/workflows/weblate-correct.yml
+++ b/.github/workflows/weblate-correct.yml
@@ -55,15 +55,17 @@ jobs:
             echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Commit Weblate fixes (verified)
+      - name: Create signed commit
         if: steps.diff.outputs.changed == 'true'
-        uses: swinton/commit@v2.x
+        id: commit
+        uses: planetscale/ghcommit-action@v0.2.20
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.WEBLATE_BOT_TOKEN || secrets.GITHUB_TOKEN }}
         with:
-          files: .
-          commit-message: "chore: run Weblate correct"
-          ref: ${{ github.event.pull_request.head.ref }}
+          commit_message: "chore: run Weblate correct"
+          repo: ${{ github.event.pull_request.head.repo.full_name }}
+          branch: ${{ github.event.pull_request.head.ref }}
+          file_pattern: .
 
       - name: Comment on PR
         if: steps.diff.outputs.changed == 'true'


### PR DESCRIPTION
## Required

- `pre-commit install` before any commit. If pre-commit wasn't run for all commits, you can squash all commits   `git reset --soft $(git merge-base main HEAD) && git commit -m "squash"` and ensure the squashed commit is properly formatted
- All commits must be signed. If some are not, you can squash all commits   `git reset --soft $(git merge-base main HEAD) && git commit -m "squash"` and ensure the squashed commit is signed
- [ ] UI/Design/Menu changes **were** tested on _macOS_, because _macOS_ creates endless problems.  Optionally attach a screenshot.
 
## Optional

- [ ] Update all translations
- [ ] Appropriate pytests were added
- [ ] Documentation is updated
- [ ] If this PR affects builds or install artifacts, set the `Build-Relevant` label to trigger build workflows
