### PR TITLE
Workflow fix weblate

### DIFF
--- a/.github/workflows/weblate-correct.yml
+++ b/.github/workflows/weblate-correct.yml
@@ -8,6 +8,7 @@ permissions:
   contents: write
   pull-requests: write
   actions: write
+  workflows: write
 
 jobs:
   run-weblate-correct:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,4 +3,4 @@
 - Never use `getattr` or `setattr`;
 - use type hints
 - write clean code.  if you're writing many if statements you're probably doing it wrong.
-- run the pre-commit for all files before commiting and ensure that you fix all bugs to fulfill the pre-commit
+- run the pre-commit for all files before commiting and ensure that you fix all bugs to fulfill the pre-commit. For that to work you have to cd into the current project and activate the environment


### PR DESCRIPTION
- pytest isnt tirggered after a successfull github bot commit

## Required

- `pre-commit install` before any commit. If pre-commit wasn't run for all commits, you can squash all commits   `git reset --soft $(git merge-base main HEAD) && git commit -m "squash"` and ensure the squashed commit is properly formatted
- All commits must be signed. If some are not, you can squash all commits   `git reset --soft $(git merge-base main HEAD) && git commit -m "squash"` and ensure the squashed commit is signed
- [ ] UI/Design/Menu changes **were** tested on _macOS_, because _macOS_ creates endless problems.  Optionally attach a screenshot.
 
## Optional

- [ ] Update all translations
- [ ] Appropriate pytests were added
- [ ] Documentation is updated
- [ ] If this PR affects builds or install artifacts, set the `Build-Relevant` label to trigger build workflows
