### PR TITLE
Workflow: run Weblate correct on Weblate force pushes

### DIFF
--- a/.github/workflows/weblate-correct.yml
+++ b/.github/workflows/weblate-correct.yml
@@ -28,17 +28,23 @@ jobs:
             const sha = pr.head.sha;
             const commit = await github.rest.repos.getCommit({ owner, repo, ref: sha });
             const login = (commit.data.author && commit.data.author.login) ? commit.data.author.login.toLowerCase() : '';
-            const shouldRun = login === 'weblate';
+            const sender = (context.payload.sender && context.payload.sender.login)
+              ? context.payload.sender.login.toLowerCase()
+              : '';
+            const shouldRun = login === 'weblate' || sender === 'weblate';
             core.info(`Last commit author: ${login || 'unknown'}`);
+            core.info(`Event sender: ${sender || 'unknown'}`);
             core.setOutput('login', login || '');
+            core.setOutput('sender', sender || '');
             core.setOutput('should_run', shouldRun ? 'true' : 'false');
 
       - name: Skip when last commit is not Weblate
         if: steps.last_commit.outputs.should_run != 'true'
         env:
           LAST_LOGIN: ${{ steps.last_commit.outputs.login }}
+          SENDER_LOGIN: ${{ steps.last_commit.outputs.sender }}
         run: |
-          echo "Last commit author (${LAST_LOGIN:-unknown}) is not Weblate; skipping workflow."
+          echo "Last commit author (${LAST_LOGIN:-unknown}) and event sender (${SENDER_LOGIN:-unknown}) are not Weblate; skipping workflow."
           exit 0
 
       - name: Check out PR branch


### PR DESCRIPTION
fixes (hopefully):  Weblate correct workflow didnt run again on weblate force push 

## Required

- `pre-commit install` before any commit. If pre-commit wasn't run for all commits, you can squash all commits   `git reset --soft $(git merge-base main HEAD) && git commit -m "squash"` and ensure the squashed commit is properly formatted
- All commits must be signed. If some are not, you can squash all commits   `git reset --soft $(git merge-base main HEAD) && git commit -m "squash"` and ensure the squashed commit is signed
- [ ] UI/Design/Menu changes **were** tested on _macOS_, because _macOS_ creates endless problems.  Optionally attach a screenshot.
 
## Optional

- [ ] Update all translations
- [ ] Appropriate pytests were added
- [ ] Documentation is updated
- [ ] If this PR affects builds or install artifacts, set the `Build-Relevant` label to trigger build workflows
