### PR TITLE
Wizard:  prevent peeking into other steps. 

### DIFF
--- a/bitcoin_safe/gui/qt/wizard.py
+++ b/bitcoin_safe/gui/qt/wizard.py
@@ -1573,6 +1573,7 @@ class Wizard(WizardBase):
             step_labels=[""] * 3,
             signals_min=qtwalletbase.signals,
             loop_in_thread=qt_wallet.loop_in_thread if qt_wallet else qtwalletbase.loop_in_thread,
+            clickable=False,
         )  # initialize with 3 steps (doesnt matter)
         logger.debug(f"__init__ {self.__class__.__name__}")
         self.qtwalletbase = qtwalletbase


### PR DESCRIPTION
peeking into other steps confuses the user... so I prevent it  
@design-rrr

## Required

- `pre-commit install` before any commit. If pre-commit wasn't run for all commits, you can squash all commits   `git reset --soft $(git merge-base main HEAD) && git commit -m "squash"` and ensure the squashed commit is properly formatted
- All commits must be signed. If some are not, you can squash all commits   `git reset --soft $(git merge-base main HEAD) && git commit -m "squash"` and ensure the squashed commit is signed
- [ ] UI/Design/Menu changes **were** tested on _macOS_, because _macOS_ creates endless problems.  Optionally attach a screenshot.
 
## Optional

- [ ] Update all translations
- [ ] Appropriate pytests were added
- [ ] Documentation is updated
- [ ] If this PR affects builds or install artifacts, set the `Build-Relevant` label to trigger build workflows
