### PR TITLE
Workflow: fix weblate correct

### DIFF
--- a/.github/workflows/weblate-correct.yml
+++ b/.github/workflows/weblate-correct.yml
@@ -8,46 +8,77 @@ permissions:
   contents: write
   pull-requests: write
   actions: write
-  workflows: write
 
 jobs:
   run-weblate-correct:
+    # Hard gate at job level: PR author + head repo + event sender must be exactly "weblate"
+    if: >
+      github.event.pull_request.user.login == 'weblate' &&
+      github.event.pull_request.head.repo.full_name == 'weblate/weblate-bitcoin-safe-bitcoin-safe' &&
+      github.actor == 'weblate'
     runs-on: ubuntu-latest
 
     steps:
-      - name: Check last commit author
+      - name: Check last commit author (hard enforcement)
         id: last_commit
         uses: actions/github-script@v7
         with:
           result-encoding: string
           script: |
             const pr = context.payload.pull_request;
+
+            // Hard-enforce expected head repo (fail closed)
+            const allowedHeadRepo = 'weblate/weblate-bitcoin-safe-bitcoin-safe';
+            if (pr.head.repo.full_name !== allowedHeadRepo) {
+              core.info(`Skipping: head repo is ${pr.head.repo.full_name}, expected ${allowedHeadRepo}`);
+              core.setOutput('login', '');
+              core.setOutput('should_run', 'false');
+              return;
+            }
+
+            // OPTIONAL: hard-enforce expected branch/ref (uncomment + set if desired)
+            // const allowedRef = 'weblate-bitcoin-safe-bitcoin-safe';
+            // if (pr.head.ref !== allowedRef) {
+            //   core.info(`Skipping: head ref is ${pr.head.ref}, expected ${allowedRef}`);
+            //   core.setOutput('login', '');
+            //   core.setOutput('should_run', 'false');
+            //   return;
+            // }
+
+            // Hard-enforce PR author + sender identity
+            const prAuthor = (pr.user?.login || '').toLowerCase();
+            const sender = (context.payload.sender?.login || '').toLowerCase();
+            if (prAuthor !== 'weblate' || sender !== 'weblate') {
+              core.info(`Skipping: prAuthor=${prAuthor || 'unknown'} sender=${sender || 'unknown'} (expected weblate/weblate)`);
+              core.setOutput('login', '');
+              core.setOutput('should_run', 'false');
+              return;
+            }
+
+            // Hard-enforce last commit GitHub-linked author is exactly "weblate"
             const owner = pr.head.repo.owner.login;
             const repo = pr.head.repo.name;
             const sha = pr.head.sha;
+
             const commit = await github.rest.repos.getCommit({ owner, repo, ref: sha });
-            const login = commit.data.author?.login ?? '';
-            const committer = commit.data.committer?.login ?? '';
-            const name = commit.data.commit?.author?.name ?? '';
-            const email = commit.data.commit?.author?.email ?? '';
-            const identity = [login, committer, name, email]
-              .filter((value) => value)
-              .join(' ')
-              .toLowerCase();
-            const shouldRun = identity.includes('weblate');
-            core.info(`Last commit identity: ${identity || 'unknown'}`);
-          echo "Last commit identity is not Weblate; skipping workflow."
+
+            // IMPORTANT: commit.data.author is the GitHub user attribution. If null -> fail closed.
+            const login = (commit.data.author && commit.data.author.login)
+              ? String(commit.data.author.login).toLowerCase()
+              : '';
+
+            const shouldRun = login === 'weblate';
+
+            core.info(`Last commit GitHub author login: ${login || 'null'}`);
             core.setOutput('login', login || '');
-            core.setOutput('sender', sender || '');
             core.setOutput('should_run', shouldRun ? 'true' : 'false');
 
       - name: Skip when last commit is not Weblate
         if: steps.last_commit.outputs.should_run != 'true'
         env:
           LAST_LOGIN: ${{ steps.last_commit.outputs.login }}
-          SENDER_LOGIN: ${{ steps.last_commit.outputs.sender }}
         run: |
-          echo "Last commit author (${LAST_LOGIN:-unknown}) and event sender (${SENDER_LOGIN:-unknown}) are not Weblate; skipping workflow."
+          echo "Last commit GitHub author (${LAST_LOGIN:-null}) is not exactly 'weblate'; skipping workflow."
           exit 0
 
       - name: Check out PR branch


### PR DESCRIPTION
## Required

- `pre-commit install` before any commit. If pre-commit wasn't run for all commits, you can squash all commits   `git reset --soft $(git merge-base main HEAD) && git commit -m "squash"` and ensure the squashed commit is properly formatted
- All commits must be signed. If some are not, you can squash all commits   `git reset --soft $(git merge-base main HEAD) && git commit -m "squash"` and ensure the squashed commit is signed
- [ ] UI/Design/Menu changes **were** tested on _macOS_, because _macOS_ creates endless problems.  Optionally attach a screenshot.
 
## Optional

- [ ] Update all translations
- [ ] Appropriate pytests were added
- [ ] Documentation is updated
- [ ] If this PR affects builds or install artifacts, set the `Build-Relevant` label to trigger build workflows
