### PR TITLE
Workflow: fix weblate correct

### DIFF
--- a/.github/workflows/weblate-correct.yml
+++ b/.github/workflows/weblate-correct.yml
@@ -14,7 +14,7 @@ jobs:
     # Hard gate at job level: PR author + head repo + event sender must be exactly "weblate"
     if: >
       github.event.pull_request.user.login == 'weblate' &&
-      github.event.pull_request.head.repo.full_name == 'weblate/weblate-bitcoin-safe-bitcoin-safe' &&
+      github.event.pull_request.head.repo.full_name == 'weblate/bitcoin-safe' &&
       github.actor == 'weblate'
     runs-on: ubuntu-latest
 
@@ -28,7 +28,7 @@ jobs:
             const pr = context.payload.pull_request;
 
             // Hard-enforce expected head repo (fail closed)
-            const allowedHeadRepo = 'weblate/weblate-bitcoin-safe-bitcoin-safe';
+            const allowedHeadRepo = 'weblate/bitcoin-safe';
             if (pr.head.repo.full_name !== allowedHeadRepo) {
               core.info(`Skipping: head repo is ${pr.head.repo.full_name}, expected ${allowedHeadRepo}`);
               core.setOutput('login', '');


### PR DESCRIPTION
## Required

- `pre-commit install` before any commit. If pre-commit wasn't run for all commits, you can squash all commits   `git reset --soft $(git merge-base main HEAD) && git commit -m "squash"` and ensure the squashed commit is properly formatted
- All commits must be signed. If some are not, you can squash all commits   `git reset --soft $(git merge-base main HEAD) && git commit -m "squash"` and ensure the squashed commit is signed
- [ ] UI/Design/Menu changes **were** tested on _macOS_, because _macOS_ creates endless problems.  Optionally attach a screenshot.
 
## Optional

- [ ] Update all translations
- [ ] Appropriate pytests were added
- [ ] Documentation is updated
- [ ] If this PR affects builds or install artifacts, set the `Build-Relevant` label to trigger build workflows
