### PR TITLE
Workflow: fix weblate correct 

### DIFF
--- a/.github/workflows/weblate-correct.yml
+++ b/.github/workflows/weblate-correct.yml
@@ -140,16 +140,15 @@ jobs:
         with:
           script: |
             const pr = context.payload.pull_request;
-            const sameRepo = pr.head.repo.full_name === context.repo.owner + '/' + context.repo.repo;
-            if (!sameRepo) {
-              core.info('Skipping test trigger because PR head is in a fork');
-              return;
-            }
+
+            // At this point, PR identity and source repo are already hard-verified.
+            // No sameRepo check needed.
+
             await github.rest.actions.createWorkflowDispatch({
               owner: context.repo.owner,
               repo: context.repo.repo,
               workflow_id: 'tests.yml',
-              ref: pr.head.ref,
+              ref: context.repo.default_branch,
             });
 
       - name: Comment on PR


### PR DESCRIPTION
## Required

- `pre-commit install` before any commit. If pre-commit wasn't run for all commits, you can squash all commits   `git reset --soft $(git merge-base main HEAD) && git commit -m "squash"` and ensure the squashed commit is properly formatted
- All commits must be signed. If some are not, you can squash all commits   `git reset --soft $(git merge-base main HEAD) && git commit -m "squash"` and ensure the squashed commit is signed
- [ ] UI/Design/Menu changes **were** tested on _macOS_, because _macOS_ creates endless problems.  Optionally attach a screenshot.
 
## Optional

- [ ] Update all translations
- [ ] Appropriate pytests were added
- [ ] Documentation is updated
- [ ] If this PR affects builds or install artifacts, set the `Build-Relevant` label to trigger build workflows
