### PR TITLE
Workflow:  trigger linux-tests directly after "weblate correct" 

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -11,7 +11,43 @@ on:
       backend:
         required: true
         type: string
+      repository:
+        required: false
+        type: string
+        default: ""
+      ref:
+        required: false
+        type: string
+        default: ""
 
+  workflow_dispatch:
+    inputs:
+      os:
+        description: "Runner OS"
+        required: true
+        type: choice
+        options:
+          - ubuntu-22.04
+          - windows-latest
+          - macos-latest
+      backend:
+        description: "Backend selector passed to pytest as --<backend>"
+        required: true
+        type: choice
+        options:
+          - fulcrum
+          - cbf
+      repository:
+        description: "Repository to checkout (owner/name). Leave empty for current repo."
+        required: false
+        type: string
+        default: ""
+      ref:
+        description: "Git ref to checkout (branch/tag/SHA). Leave empty for event ref."
+        required: false
+        type: string
+        default: ""
+        
 jobs:
   test:
     runs-on: ${{ inputs.os }}
@@ -23,8 +59,13 @@ jobs:
       DISPLAY: ":99.0"  # Display setting for Xvfb on Linux
       QT_SELECT: "qt6"  # Environment variable to select Qt6
 
+
     steps:
     - uses: actions/checkout@v4
+      with:
+        repository: ${{ inputs.repository != '' && inputs.repository || github.repository }}
+        ref: ${{ inputs.ref != '' && inputs.ref || github.ref }}
+        fetch-depth: 0
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5

--- a/.github/workflows/weblate-correct.yml
+++ b/.github/workflows/weblate-correct.yml
@@ -18,6 +18,11 @@ jobs:
       github.actor == 'weblate'
     runs-on: ubuntu-latest
 
+    outputs:
+      changed: ${{ steps.diff.outputs.changed }}
+      head_repo: ${{ github.event.pull_request.head.repo.full_name }}
+      head_ref: ${{ github.event.pull_request.head.ref }}
+
     steps:
       - name: Check last commit author (hard enforcement)
         id: last_commit
@@ -35,15 +40,6 @@ jobs:
               core.setOutput('should_run', 'false');
               return;
             }
-
-            // OPTIONAL: hard-enforce expected branch/ref (uncomment + set if desired)
-            // const allowedRef = 'weblate-bitcoin-safe-bitcoin-safe';
-            // if (pr.head.ref !== allowedRef) {
-            //   core.info(`Skipping: head ref is ${pr.head.ref}, expected ${allowedRef}`);
-            //   core.setOutput('login', '');
-            //   core.setOutput('should_run', 'false');
-            //   return;
-            // }
 
             // Hard-enforce PR author + sender identity
             const prAuthor = (pr.user?.login || '').toLowerCase();
@@ -134,23 +130,6 @@ jobs:
           branch: ${{ github.event.pull_request.head.ref }}
           file_pattern: .
 
-      - name: Trigger tests workflow
-        if: steps.diff.outputs.changed == 'true'
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const pr = context.payload.pull_request;
-
-            // At this point, PR identity and source repo are already hard-verified.
-            // No sameRepo check needed.
-
-            await github.rest.actions.createWorkflowDispatch({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              workflow_id: 'tests.yml',
-              ref: context.repo.default_branch,
-            });
-
       - name: Comment on PR
         if: steps.diff.outputs.changed == 'true'
         uses: actions/github-script@v7
@@ -164,3 +143,18 @@ jobs:
               issue_number: pr.number,
               body,
             });
+
+  linux-tests:
+    needs: run-weblate-correct
+    if: needs.run-weblate-correct.outputs.changed == 'true'
+    strategy:
+      matrix:
+        backend: [fulcrum, cbf]
+    uses: ./.github/workflows/python-tests.yml
+    secrets: inherit
+    with:
+      os: ubuntu-22.04
+      backend: ${{ matrix.backend }}
+      # NOTE: python-tests.yml must support these optional inputs
+      repository: ${{ needs.run-weblate-correct.outputs.head_repo }}
+      ref: ${{ needs.run-weblate-correct.outputs.head_ref }}


### PR DESCRIPTION
 trigger linux-tests directly after "weblate correct" 

## Required

- `pre-commit install` before any commit. If pre-commit wasn't run for all commits, you can squash all commits   `git reset --soft $(git merge-base main HEAD) && git commit -m "squash"` and ensure the squashed commit is properly formatted
- All commits must be signed. If some are not, you can squash all commits   `git reset --soft $(git merge-base main HEAD) && git commit -m "squash"` and ensure the squashed commit is signed
- [ ] UI/Design/Menu changes **were** tested on _macOS_, because _macOS_ creates endless problems.  Optionally attach a screenshot.
 
## Optional

- [ ] Update all translations
- [ ] Appropriate pytests were added
- [ ] Documentation is updated
- [ ] If this PR affects builds or install artifacts, set the `Build-Relevant` label to trigger build workflows
