### PR TITLE
Feature: Configurable number of P2P listening connections to improve reliability

### DIFF
--- a/bitcoin_safe/client.py
+++ b/bitcoin_safe/client.py
@@ -41,7 +41,7 @@ from bitcoin_safe_lib.async_tools.loop_in_thread import LoopInThread
 from bitcoin_safe.cbf.cbf_sync import CbfSync
 from bitcoin_safe.client_helpers import ProgressInfo, SyncStatus, UpdateInfo
 from bitcoin_safe.i18n import translate
-from bitcoin_safe.network_config import ElectrumConfig, Peer
+from bitcoin_safe.network_config import ElectrumConfig, Peer, Peers
 from bitcoin_safe.network_utils import ProxyInfo, clean_electrum_url
 from bitcoin_safe.p2p.peer_discovery import CBF_REQUIRED_SERVICE_FLAGS, PeerDiscovery
 
@@ -200,7 +200,7 @@ class Client:
     @classmethod
     def from_cbf(
         cls,
-        initial_peer: Peer | None,
+        manual_peers: Peers | list[Peer] | None,
         bdkwallet: bdk.Wallet,
         proxy_info: ProxyInfo | None,
         data_dir: Path,
@@ -213,8 +213,8 @@ class Client:
         """From cbf."""
         peers: set[Peer] = set()
 
-        if initial_peer:
-            peers.add(initial_peer)
+        if manual_peers:
+            peers.update(manual_peers)
 
         p2p_discovery = PeerDiscovery(network=bdkwallet.network(), loop_in_thread=loop_in_thread)
         discovered_peers = loop_in_thread.run_foreground(

--- a/bitcoin_safe/p2p/p2p_listener.py
+++ b/bitcoin_safe/p2p/p2p_listener.py
@@ -32,13 +32,17 @@ import asyncio
 import logging
 import random
 import time
+from asyncio import Queue, QueueEmpty
+from concurrent.futures import Future
+from functools import partial
 from typing import TypeVar, cast
 
 import bdkpython as bdk
 from bitcoin_safe_lib.async_tools.loop_in_thread import LoopInThread
-from bitcoin_safe_lib.gui.qt.signal_tracker import SignalProtocol
+from bitcoin_safe_lib.gui.qt.signal_tracker import SignalProtocol, SignalTracker
 from PyQt6.QtCore import QObject, pyqtSignal
 
+from bitcoin_safe.network_config import ConnectionInfo
 from bitcoin_safe.network_utils import ProxyInfo
 
 from .p2p_client import Inventory, InventoryType, P2PClient, Peer, Peers
@@ -54,6 +58,8 @@ class P2pListener(QObject):
     signal_block = cast(SignalProtocol[[str]], pyqtSignal(str))
     signal_break_current_connection = cast(SignalProtocol[[]], pyqtSignal())
     signal_disconnected_to = cast(SignalProtocol[[Peer]], pyqtSignal(Peer))
+    signal_try_connecting_to = cast(SignalProtocol[[ConnectionInfo]], pyqtSignal(ConnectionInfo))
+    signal_current_peers_change = cast(SignalProtocol[[list[ConnectionInfo]]], pyqtSignal(list))
 
     def __init__(
         self,
@@ -64,12 +70,20 @@ class P2pListener(QObject):
         timeout: int = 200,
         discovered_peers: Peers | list[Peer] | None = None,
         autodiscover_additional_peers: bool = True,
+        max_parallel_peers: int = 2,
         parent: QObject | None = None,
     ) -> None:
         """Initialize instance."""
         super().__init__(parent)
+        if max_parallel_peers < 1:
+            raise ValueError("max_parallel_peers must be >= 1")
+
         self.fetch_txs = fetch_txs
-        self.client = P2PClient(network=network, debug=debug, timeout=timeout, parent=self)
+        self.network = network
+        self.debug = debug
+        self.timeout = timeout
+        self.max_parallel_peers = max_parallel_peers
+
         self.loop_in_thread = loop_in_thread or LoopInThread()
         self._owns_loop_in_thread = loop_in_thread is None
         self.address_filter: set[str] | None = None
@@ -79,13 +93,44 @@ class P2pListener(QObject):
 
         self.discovered_peers = discovered_peers if discovered_peers else Peers()
 
-        # signals
-        self.client.signal_received_peers.connect(self.on_received_peers)
-        self.client.signal_disconnected_to.connect(self.on_disconnected_to)
-        self.signal_disconnected_to.connect(self.on_disconnected_to)
-        self.client.signal_inv.connect(self.on_inv)
-        self.client.signal_tx.connect(self.on_tx)
-        self.signal_break_current_connection.connect(self._on_break_current_connection)
+        self.signal_tracker = SignalTracker()
+        self.clients: list[P2PClient] = []
+        self._connection_tasks: list[Future[None]] = []
+        self._active_peers: set[Peer] = set()
+        self._current_peers: dict[int, ConnectionInfo | None] = {}
+        self._stop_requested = False
+
+        self.signal_tracker.connect(self.signal_disconnected_to, self.on_disconnected_to)
+        self.signal_tracker.connect(self.signal_break_current_connection, self._on_break_current_connection)
+        self._ensure_clients()
+
+    def _build_client(self, slot_id: int) -> P2PClient:
+        """Create and wire a P2PClient for the given slot."""
+        client = P2PClient(
+            network=self.network,
+            debug=self.debug,
+            timeout=self.timeout,
+            parent=self,
+        )
+        self.signal_tracker.connect(client.signal_received_peers, self.on_received_peers)
+        self.signal_tracker.connect(client.signal_disconnected_to, self.on_disconnected_to)
+        self.signal_tracker.connect(client.signal_inv, partial(self.on_inv_from_client, client))
+        self.signal_tracker.connect(client.signal_tx, self.on_tx)
+        self.signal_tracker.connect(client.signal_try_connecting_to, self.signal_try_connecting_to.emit)
+        self.signal_tracker.connect(
+            client.signal_current_peer_change, partial(self._on_current_peer_change, slot_id)
+        )
+        return client
+
+    def _ensure_clients(self) -> None:
+        """Create missing client slots without duplicating signal wiring."""
+        missing = self.max_parallel_peers - len(self.clients)
+        if missing <= 0:
+            return
+        start_slot = len(self.clients)
+        for offset in range(missing):
+            slot_id = start_slot + offset
+            self.clients.append(self._build_client(slot_id))
 
     def set_address_filter(self, address_filter: set[str] | None):
         """Set address filter."""
@@ -95,10 +140,15 @@ class P2pListener(QObject):
         """Set outpoint filter."""
         self.outpoint_filter = outpoint_filter
 
+    def _on_current_peer_change(self, slot_id: int, connection_info: ConnectionInfo | None) -> None:
+        """Track active peers per slot and emit aggregated changes."""
+        self._current_peers[slot_id] = connection_info
+        self.signal_current_peers_change.emit(self.active_connections)
+
     def on_tx(self, tx: bdk.Transaction):
         """On tx."""
         if (self.address_filter is not None) and address_match(
-            tx=tx, network=self.client.network, address_filter=self.address_filter
+            tx=tx, network=self.network, address_filter=self.address_filter
         ):
             self.signal_tx.emit(tx)
             return
@@ -110,6 +160,7 @@ class P2pListener(QObject):
         self,
         weight_getaddr: float = 0.7,
         weight_dns: float = 0.3,
+        exclude_peers: set[Peer] | None = None,
     ) -> Peer | None:
         """Pick a random peer according to two relative weights.
 
@@ -127,14 +178,17 @@ class P2pListener(QObject):
         Peer | None
             A `Peer` object, or `None` if neither source has anything.
         """
+        exclude_peers = exclude_peers or set()
         if weight_getaddr < 0 or weight_dns < 0:
             raise ValueError("weights must be non-negative")
 
         if not self.autodiscover_additional_peers:
             weight_dns = 0
 
+        discovered_candidates = [peer for peer in self.discovered_peers if peer not in exclude_peers]
+
         # Fast paths -------------------------------------------------
-        if not self.discovered_peers:
+        if not discovered_candidates:
             if not self.autodiscover_additional_peers:
                 logger.debug("Peer discovery disabled; no discovered peers available")
                 return None
@@ -142,7 +196,7 @@ class P2pListener(QObject):
             logger.debug(f"Picked {peer=} from DNS seed")
             return peer
         if weight_dns == 0:
-            peer = random.choice(self.discovered_peers)
+            peer = random.choice(discovered_candidates)
             logger.debug(f"Picked {peer=} from discovered_peers")
             return peer
 
@@ -152,8 +206,8 @@ class P2pListener(QObject):
 
         # Weighted choice -------------------------------------------
         pick = random.random() * total
-        if pick < weight_getaddr and self.discovered_peers:
-            peer = random.choice(self.discovered_peers)
+        if pick < weight_getaddr and discovered_candidates:
+            peer = random.choice(discovered_candidates)
             logger.debug(f"Picked {peer=} from discovered_peers")
             return peer
 
@@ -161,85 +215,74 @@ class P2pListener(QObject):
         logger.debug(f"Picked {peer=} from DNS seed")
         return peer
 
-    async def _start(
+    async def _next_peer_candidate(
         self,
+        preferred_queue: Queue[Peer],
+        exclude_peers: set[Peer],
+    ) -> Peer | None:
+        """Fetch the next peer from preferred list or discovery."""
+        try:
+            while True:
+                candidate = preferred_queue.get_nowait()
+                if candidate not in exclude_peers:
+                    return candidate
+        except QueueEmpty:
+            pass
+        return await self.random_select_peer(exclude_peers=exclude_peers)
+
+    async def _maintain_connection(
+        self,
+        slot_id: int,
+        client: P2PClient,
         proxy_info: ProxyInfo | None,
-        preferred_peers: list[Peer] | None = None,
+        preferred_queue: Queue[Peer],
     ) -> None:
-        """Keep the client *always* connected to **some** Bitcoin peer.
-
-        Prefers peers passed via ``preferred_peers`` (in order), then
-        peers from ``self.discovered_peers``, and finally falls back to DNS
-        seeds when allowed.
-        """
+        """Keep a single slot connected to a peer."""
+        retry_delay = 5
         previous_peer: Peer | None = None
-        peer = None
-        queued_preferred_peers = list(preferred_peers or [])
-        if queued_preferred_peers:
-            self.add_peers(Peers(queued_preferred_peers))
-        retry_delay = 5  # seconds to wait when no peer is immediately available
 
-        while True:
-            start_time: float | None = None
-
-            # ------------------------------------------------------------------
-            # 1. Select the next peer (and avoid repeating the last one immediately)
-            # ------------------------------------------------------------------
+        while not self._stop_requested:
+            peer = await self._next_peer_candidate(
+                preferred_queue=preferred_queue,
+                exclude_peers=self._active_peers,
+            )
             if peer is None:
-                if queued_preferred_peers:
-                    peer = queued_preferred_peers.pop(0)
-                else:
-                    peer = await self.random_select_peer()
-                if peer is None:
-                    # no peers at all? wait then retry
-                    await asyncio.sleep(retry_delay)
-                    continue
+                await asyncio.sleep(retry_delay)
+                continue
 
-            # if it's the same as last time, back off before retrying
             if peer == previous_peer:
-                logger.info(f"Peer {peer!r} was just tried—waiting {retry_delay}s before retry")
                 await asyncio.sleep(retry_delay)
 
-            logger.info(f"Try peer: {peer!r}")
+            self._active_peers.add(peer)
+            logger.info(f"[slot {slot_id}] Try peer: {peer!r}")
+            start_time: float | None = None
 
             try:
-                # ------------------------------------------------------------------
-                # 2. Try to connect
-                # ------------------------------------------------------------------
-                await self.client.connect(peer=peer, proxy_info=proxy_info)
+                await client.connect(peer=peer, proxy_info=proxy_info)
                 start_time = time.monotonic()
 
-                # Connection attempt failed outright → pick a new peer next loop
-                if not self.client.is_running():
-                    peer = None
+                if not client.is_running():
+                    previous_peer = peer
                     continue
 
-                # ------------------------------------------------------------------
-                # 3. We are connected – stay connected until something breaks
-                # ------------------------------------------------------------------
-                await self.client.listen_forever()  # returns on disconnect/error
+                await client.listen_forever()
 
             except asyncio.CancelledError:
-                # Allow external task-cancellation to propagate
-                await self.client.disconnect()
+                await client.disconnect()
                 raise
 
             except Exception as exc:
-                # signal disconnection, then retry a fresh peer next time
-                if peer:
-                    self.signal_disconnected_to.emit(peer)
-                logger.debug(f"Connection error with {peer}: {exc}")
+                self.signal_disconnected_to.emit(peer)
+                logger.debug(f"[slot {slot_id}] Connection error with {peer}: {exc}")
             finally:
-                # Ensure the socket is fully closed before we loop again
-                await self.client.disconnect()
+                self._active_peers.discard(peer)
+                await client.disconnect()
 
                 if peer and start_time is not None:
                     elapsed = time.monotonic() - start_time
-                    logger.info(f"Disconnected from {peer!r} after {elapsed:.2f} seconds")
+                    logger.info(f"[slot {slot_id}] Disconnected from {peer!r} after {elapsed:.2f} seconds")
 
-                # remember which peer we just tried, then force a fresh pick
                 previous_peer = peer
-                peer = None
 
     def start(
         self,
@@ -247,23 +290,62 @@ class P2pListener(QObject):
         preferred_peers: list[Peer] | None = None,
     ):
         """Start."""
-        self.loop_in_thread.run_background(
-            self._start(proxy_info=proxy_info, preferred_peers=preferred_peers)
-        )
+        self._stop_requested = False
+        for task in list(self._connection_tasks):
+            task.cancel()
+        for client in self.clients:
+            self.loop_in_thread.run_background(client.disconnect())
+        self._active_peers.clear()
+        self._current_peers = {i: None for i in range(len(self.clients))}
+        self._connection_tasks.clear()
+        self.signal_current_peers_change.emit([])
+
+        self._ensure_clients()
+
+        preferred_queue: Queue[Peer] = Queue()
+        if preferred_peers:
+            for peer in preferred_peers:
+                preferred_queue.put_nowait(peer)
+            self.add_peers(Peers(preferred_peers))
+
+        # ensure required clients exist, then (re)start tasks for the first `max_parallel_peers`
+        for slot_id, client in enumerate(self.clients[: self.max_parallel_peers]):
+            task = self.loop_in_thread.run_background(
+                self._maintain_connection(
+                    slot_id=slot_id,
+                    client=client,
+                    proxy_info=proxy_info,
+                    preferred_queue=preferred_queue,
+                )
+            )
+            self._connection_tasks.append(task)
 
     def stop(self):
         """Stop."""
         self.peer_discovery.stop()
-        if self._owns_loop_in_thread:
-            self.loop_in_thread.stop()
+        self._stop_requested = True
+        for task in list(self._connection_tasks):
+            task.cancel()
+        self._connection_tasks.clear()
+        for client in self.clients:
+            self.loop_in_thread.run_background(client.disconnect())
+        self._active_peers.clear()
+        self._current_peers = {i: None for i in range(len(self.clients))}
+        self.signal_current_peers_change.emit([])
 
-    def do_fetch_txs(self, inventory: Inventory):
+    @property
+    def active_connections(self) -> list[ConnectionInfo]:
+        """List of active connections."""
+        return [info for info in self._current_peers.values() if info]
+
+    def do_fetch_txs(self, client: P2PClient, inventory: Inventory):
         """Do fetch txs."""
         tx_inventory = Inventory()
         for item in inventory:
             if item.type in [InventoryType.MSG_TX, InventoryType.MSG_WITNESS_TX]:
                 tx_inventory.append(item)
-        self.loop_in_thread.run_background(self.client.getdata(tx_inventory))
+        if tx_inventory:
+            self.loop_in_thread.run_background(client.getdata(tx_inventory))
 
     def handle_block_msg(self, inventory: Inventory):
         """Handle block msg."""
@@ -277,10 +359,10 @@ class P2pListener(QObject):
                 logger.info(f"Block: {item.type=} {block_hash=}")
                 self.signal_block.emit(block_hash)
 
-    def on_inv(self, inventory: Inventory):
+    def on_inv_from_client(self, client: P2PClient, inventory: Inventory):
         """On inv."""
         if self.fetch_txs:
-            self.do_fetch_txs(inventory=inventory)
+            self.do_fetch_txs(client=client, inventory=inventory)
         self.handle_block_msg(inventory=inventory)
 
     def on_disconnected_to(self, peer: Peer):
@@ -326,6 +408,6 @@ class P2pListener(QObject):
 
         We can’t `await` inside a Qt slot, so we schedule the coroutine.
         """
-        if not self.client.is_running():  # already closed
-            return
-        self.loop_in_thread.run_background(self.client.disconnect())
+        for client in self.clients:
+            if client.is_running():
+                self.loop_in_thread.run_background(client.disconnect())

--- a/bitcoin_safe/wallet.py
+++ b/bitcoin_safe/wallet.py
@@ -1236,7 +1236,7 @@ class Wallet(BaseSaveableClass, CacheManager):
             # )
         elif self.config.network_config.server_type == BlockchainType.CompactBlockFilter:
             client = Client.from_cbf(
-                initial_peer=self.config.network_config.get_p2p_initial_peer(),
+                manual_peers=self.config.network_config.get_manual_peers(),
                 bdkwallet=self.bdkwallet,
                 gap=self.gap,
                 proxy_info=proxy_info,

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -36,7 +36,7 @@ import bdkpython as bdk
 import pytest
 
 from bitcoin_safe.config import UserConfig
-from bitcoin_safe.network_config import P2pListenerType
+from bitcoin_safe.network_config import P2pListenerType, Peer
 from bitcoin_safe.pythonbdk_types import BlockchainType
 
 from .setup_bitcoin_core import BITCOIN_HOST, BITCOIN_LISTEN_PORT
@@ -51,8 +51,10 @@ def _configure_network_backend(config: TestConfig, backend: str, fulcrum: str | 
         config.network_config.server_type = BlockchainType.CompactBlockFilter
         config.network_config.cbf_connections = 1
 
-        config.network_config.p2p_listener_type = P2pListenerType.inital
-        config.network_config.p2p_inital_url = f"{BITCOIN_HOST}:{BITCOIN_LISTEN_PORT}"
+        config.network_config.p2p_listener_type = P2pListenerType.automatic
+        config.network_config.manual_peers.append(
+            Peer.parse(url=f"{BITCOIN_HOST}:{BITCOIN_LISTEN_PORT}", network=config.network)
+        )
         config.network_config.p2p_autodiscover_additional_peers = False
     else:
         assert fulcrum, "Fulcrum backend requested but no server URL provided"


### PR DESCRIPTION
- makes the number of p2p connections configurable and sets the default to 2
- improves/generalizes the gui
- [ ] test if 2 is actually necessary or the default can be 1 . Hard to test.  But considering that < 1 Sat/vB made propagation less reliable, 2 seems a good default
- [x] check migration works for different settings

<img width="430" height="149" alt="image" src="https://github.com/user-attachments/assets/650260f8-10df-4f88-af30-af9abf8ca56c" />
<img width="500" height="173" alt="image" src="https://github.com/user-attachments/assets/91e07b8b-8d64-4d5d-93a3-25dd1e6f3a4f" />


## Required

- `pre-commit install` before any commit. If pre-commit wasn't run for all commits, you can squash all commits   `git reset --soft $(git merge-base main HEAD) && git commit -m "squash"` and ensure the squashed commit is properly formatted
- All commits must be signed. If some are not, you can squash all commits   `git reset --soft $(git merge-base main HEAD) && git commit -m "squash"` and ensure the squashed commit is signed
- [x] UI/Design/Menu changes **were** tested on _macOS_, because _macOS_ creates endless problems.  Optionally attach a screenshot.
 
## Optional

- [ ] Update all translations
- [ ] Appropriate pytests were added
- [x] Documentation is updated
- [ ] If this PR affects builds or install artifacts, set the `Build-Relevant` label to trigger build workflows
