### PR TITLE
Wizard:  disable previous step after qt_wallet creation

### DIFF
--- a/bitcoin_safe/gui/qt/wizard.py
+++ b/bitcoin_safe/gui/qt/wizard.py
@@ -279,6 +279,8 @@ class BaseTab(QObject):
         self.refs = refs
         super().__init__(parent=refs.container)
 
+        self.previous_step_enabled = True
+
         self.loop_in_thread = loop_in_thread
         self.signal_tracker = SignalTracker()
         self.buttonbox, self.buttonbox_buttons = create_button_box(
@@ -310,6 +312,7 @@ class BaseTab(QObject):
         """UpdateUi."""
         self.button_next.setText(translate("basetab", "Next step"))
         self.button_previous.setText(translate("basetab", "Previous Step"))
+        self.button_previous.setEnabled(self.previous_step_enabled)
         self.refs.floating_button_box.updateUi()
 
     def num_keystores(self) -> int:
@@ -876,6 +879,11 @@ class ImportXpubs(BaseTab):
 
 
 class BackupSeed(BaseTab):
+    def __init__(self, refs: WizardTabInfo, loop_in_thread: LoopInThread) -> None:
+        super().__init__(refs, loop_in_thread)
+
+        self.previous_step_enabled = False
+
     def _do_pdf(self) -> None:
         """Do pdf."""
         if not self.refs.qt_wallet:
@@ -936,6 +944,7 @@ class BackupSeed(BaseTab):
 
         self.custom_yes_button.setText(self.tr("Print recovery sheet"))
         self.custom_cancel_button.setText(self.tr("Previous Step"))
+        self.custom_cancel_button.setEnabled(self.previous_step_enabled)
 
         glue_statement = (
             self.tr("Glue the {number} word seed onto the matching printed pdf.").format(number=TEXT_24_WORDS)

--- a/tests/gui/qt/test_setup_wallet.py
+++ b/tests/gui/qt/test_setup_wallet.py
@@ -316,6 +316,8 @@ def test_wizard(
                 shutter.save(main_window)
                 step = wizard.tab_generators[TutorialStep.backup_seed]
                 assert isinstance(step, BackupSeed)
+                assert not step.button_previous.isEnabled()
+                assert not step.custom_cancel_button.isEnabled()
                 with patch("bitcoin_safe.pdfrecovery.xdg_open_file") as mock_open:
                     assert step.custom_yes_button.isVisible()
                     step.custom_yes_button.click()


### PR DESCRIPTION
- disable backbutton when it doesnt make sense

## Required

- `pre-commit install` before any commit. If pre-commit wasn't run for all commits, you can squash all commits   `git reset --soft $(git merge-base main HEAD) && git commit -m "squash"` and ensure the squashed commit is properly formatted
- All commits must be signed. If some are not, you can squash all commits   `git reset --soft $(git merge-base main HEAD) && git commit -m "squash"` and ensure the squashed commit is signed
- [ ] UI/Design/Menu changes **were** tested on _macOS_, because _macOS_ creates endless problems.  Optionally attach a screenshot.
 
## Optional

- [ ] Update all translations
- [x] Appropriate pytests were added
- [ ] Documentation is updated
- [ ] If this PR affects builds or install artifacts, set the `Build-Relevant` label to trigger build workflows
