### PR TITLE
Keep tx viewer tabs open on tx removal

### DIFF
--- a/bitcoin_safe/gui/qt/qt_wallet.py
+++ b/bitcoin_safe/gui/qt/qt_wallet.py
@@ -1008,10 +1008,6 @@ class QTWallet(QtWalletBase, BaseSaveableClass):
                     fd = os.open(filename, os.O_CREAT | os.O_WRONLY)
                     data.write_to_filedescriptor(fd)
                     logger.info(f"Exported {tx.txid} to {filename}")
-        else:
-            self.signals.signal_close_tabs_with_txids.emit(
-                [str(tx.transaction.compute_txid()) for tx in removed_txs]
-            )
 
         self.notified_tx_ids -= set([tx.txid for tx in removed_txs])
         # all the lists must be updated


### PR DESCRIPTION
- Closing txviewer, (even after the user Oked the removal from the wallet), is not good.  Reason:  if the user wants to do edit the TX , he was asked to remove the local tx from the wallet first. 

## Required

- `pre-commit install` before any commit. If pre-commit wasn't run for all commits, you can squash all commits   `git reset --soft $(git merge-base main HEAD) && git commit -m "squash"` and ensure the squashed commit is properly formatted
- All commits must be signed. If some are not, you can squash all commits   `git reset --soft $(git merge-base main HEAD) && git commit -m "squash"` and ensure the squashed commit is signed
- [ ] UI/Design/Menu changes **were** tested on _macOS_, because _macOS_ creates endless problems.  Optionally attach a screenshot.
 
## Optional

- [ ] Update all translations
- [ ] Appropriate pytests were added
- [ ] Documentation is updated
- [ ] If this PR affects builds or install artifacts, set the `Build-Relevant` label to trigger build workflows
