### PR TITLE
Add restart verification to mac, appimage, and portable workflows

### DIFF
--- a/.github/workflows/build-and-test-mac.yml
+++ b/.github/workflows/build-and-test-mac.yml
@@ -126,6 +126,39 @@ jobs:
 
       - name: Start DMG file on ${{ matrix.arch }}
         run: |
+          set -euo pipefail
+
+          find_app_pids() {
+            pgrep -f "/Bitcoin Safe.app/Contents/MacOS/Bitcoin Safe" || true
+          }
+
+          wait_for_pid_to_exit() {
+            target_pid="$1"
+            timeout_seconds="$2"
+            for _ in $(seq 1 "$timeout_seconds"); do
+              if ! kill -0 "$target_pid" 2>/dev/null; then
+                return 0
+              fi
+              sleep 1
+            done
+            return 1
+          }
+
+          wait_for_new_pid() {
+            old_pid="$1"
+            timeout_seconds="$2"
+            for _ in $(seq 1 "$timeout_seconds"); do
+              for pid in $(find_app_pids); do
+                if [ "$pid" != "$old_pid" ]; then
+                  echo "$pid"
+                  return 0
+                fi
+              done
+              sleep 1
+            done
+            return 1
+          }
+
           # Find the DMG file from the downloaded artifacts.
           DMG_FILE=$(find dmgs -type f -name '*.dmg' | head -n 1)
           if [ -z "$DMG_FILE" ]; then
@@ -193,10 +226,88 @@ jobs:
           else
             echo "Bitcoin Safe is running." | tee -a test_dmg.log
           fi
- 
-          # Optionally, you can run further tests against the application.
-          
-          
+
+          # Capture a baseline PID and verify restart via the Network Settings UI.
+          INITIAL_PID=$(find_app_pids | head -n 1)
+          if [ -z "$INITIAL_PID" ]; then
+            echo "Could not determine initial app PID before restart test." | tee -a test_dmg.log
+            exit 1
+          fi
+          echo "Initial app PID: $INITIAL_PID" | tee -a test_dmg.log
+
+          echo "Opening Network Settings and clicking 'Apply and restart'..." | tee -a test_dmg.log
+          osascript <<'APPLESCRIPT'
+          tell application "Bitcoin Safe" to activate
+          delay 1
+          tell application "System Events"
+            tell process "Bitcoin Safe"
+              set frontmost to true
+              keystroke "," using command down
+            end tell
+          end tell
+          APPLESCRIPT
+
+          # Wait until the settings dialog is available, then click Apply and restart.
+          for i in $(seq 1 20); do
+            if osascript <<'APPLESCRIPT'
+            tell application "System Events"
+              tell process "Bitcoin Safe"
+                if exists (window "Network Settings") then
+                  click button "Apply and restart" of window "Network Settings"
+                  return "clicked"
+                end if
+              end tell
+            end tell
+            APPLESCRIPT
+            then
+              echo "Clicked Apply and restart." | tee -a test_dmg.log
+              break
+            fi
+            if [ "$i" -eq 20 ]; then
+              echo "Network Settings dialog or Apply and restart button not found." | tee -a test_dmg.log
+              exit 1
+            fi
+            sleep 1
+          done
+
+          # If server checks fail, a confirmation dialog can appear; accept it.
+          osascript <<'APPLESCRIPT' || true
+          tell application "System Events"
+            tell process "Bitcoin Safe"
+              repeat 5 times
+                try
+                  if exists button "Yes" of window 1 then
+                    click button "Yes" of window 1
+                    exit repeat
+                  end if
+                end try
+                delay 1
+              end repeat
+            end tell
+          end tell
+          APPLESCRIPT
+
+          if wait_for_pid_to_exit "$INITIAL_PID" 90; then
+            echo "Old process exited as expected." | tee -a test_dmg.log
+          else
+            echo "Old process (PID $INITIAL_PID) did not exit after restart request." | tee -a test_dmg.log
+            exit 1
+          fi
+
+          NEW_PID=$(wait_for_new_pid "$INITIAL_PID" 90 || true)
+          if [ -z "$NEW_PID" ]; then
+            echo "No new process detected after restart request." | tee -a test_dmg.log
+            exit 1
+          fi
+          echo "Detected restarted app with new PID: $NEW_PID" | tee -a test_dmg.log
+
+          # Confirm the app process remains alive after restart.
+          sleep 5
+          if ! kill -0 "$NEW_PID" 2>/dev/null; then
+            echo "Restarted process exited unexpectedly (PID $NEW_PID)." | tee -a test_dmg.log
+            exit 1
+          fi
+          echo "Restart verification succeeded." | tee -a test_dmg.log
         shell: bash
 
 

--- a/.github/workflows/build-appimage-and-test.yml
+++ b/.github/workflows/build-appimage-and-test.yml
@@ -298,6 +298,90 @@ jobs:
             exit 1
           fi
 
+      - name: Verify restart from Network Settings on AppImage
+        if: matrix.package == 'appimage'
+        run: |
+          set -euo pipefail
+
+          APP_CMD=$(cat package_path.txt)
+
+          find_app_pids() {
+            pgrep -f -- "$APP_CMD" || true
+          }
+
+          wait_for_pid_to_exit() {
+            target_pid="$1"
+            timeout_seconds="$2"
+            for _ in $(seq 1 "$timeout_seconds"); do
+              if ! kill -0 "$target_pid" 2>/dev/null; then
+                return 0
+              fi
+              sleep 1
+            done
+            return 1
+          }
+
+          wait_for_new_pid() {
+            old_pid="$1"
+            timeout_seconds="$2"
+            for _ in $(seq 1 "$timeout_seconds"); do
+              for pid in $(find_app_pids); do
+                if [ "$pid" != "$old_pid" ]; then
+                  echo "$pid"
+                  return 0
+                fi
+              done
+              sleep 1
+            done
+            return 1
+          }
+
+          INITIAL_PID=$(find_app_pids | head -n 1)
+          if [ -z "$INITIAL_PID" ]; then
+            echo "Could not determine initial app PID before restart test."
+            exit 1
+          fi
+          echo "Initial app PID: $INITIAL_PID"
+
+          WINDOW_ID=$(xdotool search --name "Bitcoin Safe" | head -n 1 || true)
+          if [ -z "$WINDOW_ID" ]; then
+            echo "Could not find Bitcoin Safe window for restart test."
+            exit 1
+          fi
+          echo "Using window id: $WINDOW_ID"
+
+          xdotool windowactivate --sync "$WINDOW_ID"
+          xdotool key --clearmodifiers ctrl+comma
+          sleep 2
+          xdotool key --clearmodifiers Return
+
+          # If a confirmation dialog appears, try to accept it.
+          sleep 1
+          xdotool key --clearmodifiers y || true
+          xdotool key --clearmodifiers Return || true
+
+          if wait_for_pid_to_exit "$INITIAL_PID" 120; then
+            echo "Old process exited as expected."
+          else
+            echo "Old process (PID $INITIAL_PID) did not exit after restart request."
+            exit 1
+          fi
+
+          NEW_PID=$(wait_for_new_pid "$INITIAL_PID" 120 || true)
+          if [ -z "$NEW_PID" ]; then
+            echo "No new process detected after restart request."
+            exit 1
+          fi
+          echo "Detected restarted app with new PID: $NEW_PID"
+          echo "$NEW_PID" > app_launch.pid
+
+          sleep 5
+          if ! kill -0 "$NEW_PID" 2>/dev/null; then
+            echo "Restarted process exited unexpectedly (PID $NEW_PID)."
+            exit 1
+          fi
+          echo "Restart verification succeeded."
+
       - name: Capture screenshot
         run: |
           xwd -root -silent -display "$DISPLAY" -out "screenshot-${{ matrix.package }}.xwd"

--- a/.github/workflows/build-windows-and-test.yml
+++ b/.github/workflows/build-windows-and-test.yml
@@ -304,6 +304,75 @@ jobs:
             }
             Write-Log "Verified 'pyzbar could be loaded successfully' in application log."
 
+            function Get-ProcessIdsForPath([string]$ExecutablePath) {
+              $exeName = [System.IO.Path]::GetFileName($ExecutablePath)
+              $procs = Get-CimInstance Win32_Process -Filter "Name='$exeName'" -ErrorAction SilentlyContinue |
+                Where-Object { $_.ExecutablePath -eq $ExecutablePath } |
+                Select-Object -ExpandProperty ProcessId
+              if ($null -eq $procs) {
+                return @()
+              }
+              return @($procs)
+            }
+
+            function Wait-ProcessExitById([int]$Pid, [int]$TimeoutSeconds) {
+              for ($i = 0; $i -lt $TimeoutSeconds; $i++) {
+                if (-not (Get-Process -Id $Pid -ErrorAction SilentlyContinue)) {
+                  return $true
+                }
+                Start-Sleep -Seconds 1
+              }
+              return $false
+            }
+
+            function Wait-NewProcessIdByPath([string]$ExecutablePath, [int]$OldPid, [int]$TimeoutSeconds) {
+              for ($i = 0; $i -lt $TimeoutSeconds; $i++) {
+                $ids = Get-ProcessIdsForPath -ExecutablePath $ExecutablePath
+                foreach ($id in $ids) {
+                  if ($id -ne $OldPid) {
+                    return $id
+                  }
+                }
+                Start-Sleep -Seconds 1
+              }
+              return $null
+            }
+
+            $initialPid = $process.Id
+            Write-Log "Initial app PID before restart test: $initialPid"
+
+            Add-Type -AssemblyName Microsoft.VisualBasic
+            [void][Microsoft.VisualBasic.Interaction]::AppActivate($process.Id)
+            Start-Sleep -Milliseconds 700
+            [System.Windows.Forms.SendKeys]::SendWait("^{,}")
+            Start-Sleep -Seconds 2
+            [System.Windows.Forms.SendKeys]::SendWait("{ENTER}")
+            Start-Sleep -Milliseconds 500
+            [System.Windows.Forms.SendKeys]::SendWait("y")
+            Start-Sleep -Milliseconds 500
+            [System.Windows.Forms.SendKeys]::SendWait("{ENTER}")
+            Write-Log "Triggered restart via keyboard sequence (Ctrl+, then Enter)."
+
+            if (-not (Wait-ProcessExitById -Pid $initialPid -TimeoutSeconds 120)) {
+              throw "Old process $initialPid did not exit after restart request."
+            }
+            Write-Log "Old process exited as expected."
+
+            $newPid = Wait-NewProcessIdByPath -ExecutablePath $portableExe.FullName -OldPid $initialPid -TimeoutSeconds 120
+            if (-not $newPid) {
+              throw "No new process found for $($portableExe.FullName) after restart request."
+            }
+            Write-Log "Detected restarted process with PID $newPid."
+
+            Start-Sleep -Seconds 5
+            $restartedProcess = Get-Process -Id $newPid -ErrorAction SilentlyContinue
+            if (-not $restartedProcess) {
+              throw "Restarted process exited unexpectedly (PID $newPid)."
+            }
+
+            $process = $restartedProcess
+            Write-Log "Restart verification succeeded."
+
           } finally {
             if ($process -and -not $process.HasExited) {
               Write-Log "Stopping process $($process.Id)."


### PR DESCRIPTION
## Required

- `pre-commit install` before any commit. If pre-commit wasn't run for all commits, you can squash all commits   `git reset --soft $(git merge-base main HEAD) && git commit -m "squash"` and ensure the squashed commit is properly formatted
- All commits must be signed. If some are not, you can squash all commits   `git reset --soft $(git merge-base main HEAD) && git commit -m "squash"` and ensure the squashed commit is signed
- [ ] UI/Design/Menu changes **were** tested on _macOS_, because _macOS_ creates endless problems.  Optionally attach a screenshot.
 
## Optional

- [ ] Update all translations
- [ ] Appropriate pytests were added
- [ ] Documentation is updated
- [ ] If this PR affects builds or install artifacts, set the `Build-Relevant` label to trigger build workflows
