### PR TITLE
CBF widget iteration bug fix

### DIFF
--- a/bitcoin_safe/gui/qt/initial_cbf_sync_widget.py
+++ b/bitcoin_safe/gui/qt/initial_cbf_sync_widget.py
@@ -553,9 +553,9 @@ class InitialCbfSyncWidget(QWidget):
         return points
 
     def _refresh_points_and_legend(self) -> None:
-        p2p_hosts = [peer.host for peer in self._p2p_connections]
+        p2p_hosts = [peer.host for peer in tuple(self._p2p_connections)]
         p2p_host_set = set(p2p_hosts)
-        node_hosts = [peer.host for peer in self._nodes if peer.host not in p2p_host_set]
+        node_hosts = [peer.host for peer in tuple(self._nodes) if peer.host not in p2p_host_set]
 
         node_points = self._build_mapped_points(node_hosts, PeerSource.node)
         p2p_points = self._build_mapped_points(p2p_hosts, PeerSource.p2p_listener)


### PR DESCRIPTION
## Required

- `pre-commit install` before any commit. If pre-commit wasn't run for all commits, you can squash all commits   `git reset --soft $(git merge-base main HEAD) && git commit -m "squash"` and ensure the squashed commit is properly formatted
- All commits must be signed. If some are not, you can squash all commits   `git reset --soft $(git merge-base main HEAD) && git commit -m "squash"` and ensure the squashed commit is signed
- [ ] UI/Design/Menu changes **were** tested on _macOS_, because _macOS_ creates endless problems.  Optionally attach a screenshot.
 
## Optional

- [ ] Update all translations
- [ ] Appropriate pytests were added
- [ ] Documentation is updated
- [ ] If this PR affects builds or install artifacts, set the `Build-Relevant` label to trigger build workflows
