### PR TITLE
Fix sidebar trailing button parenting

### DIFF
--- a/bitcoin_safe/gui/qt/sidebar/sidebar_tree.py
+++ b/bitcoin_safe/gui/qt/sidebar/sidebar_tree.py
@@ -556,12 +556,12 @@ class SidebarNode(QFrame, Generic[TT]):
         self.header_row.square_buttons.clear()
 
         if self.closable:
-            close_btn = CloseButton()
+            close_btn = CloseButton(parent=self.header_row)
             close_btn.clicked.connect(partial(self.closeClicked.emit, self))
             self.header_row.add_square_button(close_btn)
 
         if self.hidable:
-            hide_btn = HideButton()
+            hide_btn = HideButton(parent=self.header_row)
             hide_btn.clicked.connect(partial(self.hideClicked.emit, self))
             hide_btn.clicked.connect(partial(self.setVisible, False))
             self.header_row.add_square_button(hide_btn)
@@ -579,7 +579,8 @@ class SidebarNode(QFrame, Generic[TT]):
         if self.toggle_btn:
             return
         self.toggle_btn = FlatSquareButton(
-            (self.style() or QStyle()).standardIcon(QStyle.StandardPixmap.SP_ArrowDown)
+            (self.style() or QStyle()).standardIcon(QStyle.StandardPixmap.SP_ArrowDown),
+            parent=self.header_row,
         )
         self.toggle_btn.setChecked(not self.initially_collapsed)
         self.toggle_btn.clicked.connect(self._toggle_children)


### PR DESCRIPTION
## Required

- `pre-commit install` before any commit. If pre-commit wasn't run for all commits, you can squash all commits   `git reset --soft $(git merge-base main HEAD) && git commit -m "squash"` and ensure the squashed commit is properly formatted
- All commits must be signed. If some are not, you can squash all commits   `git reset --soft $(git merge-base main HEAD) && git commit -m "squash"` and ensure the squashed commit is signed
- [ ] UI/Design/Menu changes **were** tested on _macOS_, because _macOS_ creates endless problems.  Optionally attach a screenshot.
 
## Optional

- [ ] Update all translations
- [ ] Appropriate pytests were added
- [ ] Documentation is updated
- [ ] If this PR affects builds or install artifacts, set the `Build-Relevant` label to trigger build workflows
