### PR TITLE
Improve startup window probe widget paths

### DIFF
--- a/bitcoin_safe/gui/qt/startup_window_probe.py
+++ b/bitcoin_safe/gui/qt/startup_window_probe.py
@@ -109,10 +109,25 @@ class StartupWindowProbe(QObject):
 
     @staticmethod
     def _format_widget(widget: QWidget) -> str:
-        parent = widget.parentWidget()
-        parent_name = parent.__class__.__name__ if parent else None
-        button_text = widget.text() if isinstance(widget, QPushButton) else ""
-        return (
-            f"class={widget.__class__.__name__} title={widget.windowTitle()!r} "
-            f"object={widget.objectName()!r} text={button_text!r} parent={parent_name}"
-        )
+        chain: list[str] = []
+        current: QWidget | None = widget
+        while current:
+            chain.append(StartupWindowProbe._format_widget_segment(current))
+            current = current.parentWidget()
+        return " > ".join(reversed(chain))
+
+    @staticmethod
+    def _format_widget_segment(widget: QWidget) -> str:
+        label_parts: list[str] = []
+        if widget.windowTitle():
+            label_parts.append(widget.windowTitle())
+        if widget.objectName():
+            label_parts.append(f"#{widget.objectName()}")
+        if isinstance(widget, QPushButton) and widget.text():
+            label_parts.append(widget.text())
+
+        if not label_parts:
+            return widget.__class__.__name__
+
+        label = " | ".join(repr(part) for part in label_parts)
+        return f"{widget.__class__.__name__}[{label}]"

--- a/tests/non_gui/test_startup_window_probe.py
+++ b/tests/non_gui/test_startup_window_probe.py
@@ -1,0 +1,59 @@
+#
+# Bitcoin Safe
+# Copyright (C) 2026 Andreas Griffin
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of version 3 of the GNU General Public License as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see https://www.gnu.org/licenses/gpl-3.0.html
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+# BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+# ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
+from __future__ import annotations
+
+from PyQt6.QtWidgets import QApplication, QPushButton, QWidget
+
+from bitcoin_safe.gui.qt.startup_window_probe import StartupWindowProbe
+
+
+class RootWindow(QWidget):
+    pass
+
+
+class DetailsPanel(QWidget):
+    pass
+
+
+def test_format_widget_includes_parent_chain(qapp: QApplication) -> None:
+    root = RootWindow()
+    root.setWindowTitle("Bitcoin Safe")
+
+    panel = DetailsPanel(root)
+    panel.setObjectName("details_panel")
+
+    button = QPushButton("Donate", panel)
+    button.setObjectName("donate_button")
+
+    assert StartupWindowProbe._format_widget(button) == (
+        "RootWindow['Bitcoin Safe'] > "
+        "DetailsPanel['#details_panel'] > "
+        "QPushButton['#donate_button' | 'Donate']"
+    )


### PR DESCRIPTION
## Required

- `pre-commit install` before any commit. If pre-commit wasn't run for all commits, you can squash all commits   `git reset --soft $(git merge-base main HEAD) && git commit -m "squash"` and ensure the squashed commit is properly formatted
- All commits must be signed. If some are not, you can squash all commits   `git reset --soft $(git merge-base main HEAD) && git commit -m "squash"` and ensure the squashed commit is signed
- [ ] UI/Design/Menu changes **were** tested on _macOS_, because _macOS_ creates endless problems.  Optionally attach a screenshot.
 
## Optional

- [ ] Update all translations
- [ ] Appropriate pytests were added
- [ ] Documentation is updated
- [ ] If this PR affects builds or install artifacts, set the `Build-Relevant` label to trigger build workflows
