### PR TITLE
Avoid floating sidebar close buttons during rebuild

### DIFF
--- a/bitcoin_safe/gui/qt/sidebar/sidebar_tree.py
+++ b/bitcoin_safe/gui/qt/sidebar/sidebar_tree.py
@@ -552,7 +552,7 @@ class SidebarNode(QFrame, Generic[TT]):
         # Clear existing trailing buttons (except the sidebar_btn)
         """Rebuild trailing buttons."""
         for btn in list(self.header_row.square_buttons):
-            btn.setParent(None)
+            btn.hide()
         self.header_row.square_buttons.clear()
 
         if self.closable:
@@ -571,7 +571,7 @@ class SidebarNode(QFrame, Generic[TT]):
             self._ensure_toggle_button()
         else:
             if self.toggle_btn:
-                self.toggle_btn.setParent(None)
+                self.toggle_btn.hide()
                 self.toggle_btn = None
 
     def _ensure_toggle_button(self) -> None:
@@ -593,7 +593,7 @@ class SidebarNode(QFrame, Generic[TT]):
             self._ensure_toggle_button()
         else:
             if self.toggle_btn:
-                self.toggle_btn.setParent(None)
+                self.toggle_btn.hide()
                 self.toggle_btn = None
 
     def _sync_content_visibility(self) -> None:


### PR DESCRIPTION
## Required

- `pre-commit install` before any commit. If pre-commit wasn't run for all commits, you can squash all commits   `git reset --soft $(git merge-base main HEAD) && git commit -m "squash"` and ensure the squashed commit is properly formatted
- All commits must be signed. If some are not, you can squash all commits   `git reset --soft $(git merge-base main HEAD) && git commit -m "squash"` and ensure the squashed commit is signed
- [ ] UI/Design/Menu changes **were** tested on _macOS_, because _macOS_ creates endless problems.  Optionally attach a screenshot.
 
## Optional

- [ ] Update all translations
- [ ] Appropriate pytests were added
- [ ] Documentation is updated
- [ ] If this PR affects builds or install artifacts, set the `Build-Relevant` label to trigger build workflows
