### PR TITLE
Fix sidebar stack handling

### DIFF
--- a/bitcoin_safe/gui/qt/sidebar/sidebar_tree.py
+++ b/bitcoin_safe/gui/qt/sidebar/sidebar_tree.py
@@ -316,6 +316,12 @@ class SidebarNode(QFrame, Generic[TT]):
         if not visible and self.header_row.is_selected():
             self.nodeUnSelected.emit(self)
 
+    def hide(self):
+        self.setVisible(False)
+
+    def show(self):
+        self.setVisible(True)
+
     # -------------------- Public API: mutation-friendly --------------------
 
     def setTitle(self, text: str) -> None:
@@ -398,23 +404,49 @@ class SidebarNode(QFrame, Generic[TT]):
         if focus and (node.stack is not None or node._ensure_stack_link()):
             node.select()
 
+    def _detach_from_stack(self) -> None:
+        """Detach this subtree from the current stack without destroying its children."""
+        for child in self.child_nodes:
+            child._detach_from_stack()
+        if self.widget and self.stack and self.stack.indexOf(self.widget) != -1:
+            self.stack.removeWidget(self.widget)
+        self.stack = None
+
+    def _disconnect_child_signals(self, node: SidebarNode[TT]) -> None:
+        """Disconnect the signal forwarding installed by insertChildNode."""
+        try:
+            node.closeClicked.disconnect(self.closeClicked)
+        except TypeError:
+            pass
+        try:
+            node.nodeSelected.disconnect(self._bubble_selected)
+        except TypeError:
+            pass
+        try:
+            node.nodeUnSelected.disconnect(self._bubble_unselected)
+        except TypeError:
+            pass
+        try:
+            node.nodeToggled.disconnect(self._bubble_toggled)
+        except TypeError:
+            pass
+
     def removeChildNode(self, node: SidebarNode[TT]) -> None:
         """RemoveChildNode."""
-        node.clearChildren()
-
         try:
             idx = self.child_nodes.index(node)
         except ValueError:
             return
 
-        # 1) Remove from our model/layout
+        self._disconnect_child_signals(node)
+        node._detach_from_stack()
+
+        # Detaching a node must not overwrite its own visibility state because
+        # callers may reinsert the same subtree later.
         node.setParent(None)
+        node.parent_node = None
         self.child_nodes.pop(idx)
         self.content_layout.removeWidget(node)
-
-        # 2) Also purge its widget page if present
-        if node.widget and self.stack and self.stack.indexOf(node.widget) != -1:
-            self.stack.removeWidget(node.widget)
 
         self._sync_content_visibility()
         self._sync_toggle_button_visibility()
@@ -829,7 +861,7 @@ class SidebarNode(QFrame, Generic[TT]):
         else:
             return self.parent_node.get_nested_titles() + [self.title]
 
-    def select_by_titles(self, titles: list[str]):
+    def select_by_titles(self, titles: list[str], force_visible=True):
         if not titles:
             return
         node = self.findNodeByTitle(titles[0])
@@ -841,6 +873,9 @@ class SidebarNode(QFrame, Generic[TT]):
             node.select()
         else:
             node.select_by_titles(new_titles)
+
+        if force_visible:
+            node.setVisible(True)
 
     def set_current_tab_by_text(self, title: str):
         """Set current tab by text."""
@@ -981,8 +1016,8 @@ class SidebarTree(QWidget, Generic[TT]):
         self._shortcut_next = QShortcut(QKeySequence("Ctrl+PgDown"), self)
         self._shortcut_prev.setContext(Qt.ShortcutContext.ApplicationShortcut)
         self._shortcut_next.setContext(Qt.ShortcutContext.ApplicationShortcut)
-        self._shortcut_prev.activated.connect(lambda: self._select_relative(-1))
-        self._shortcut_next.activated.connect(lambda: self._select_relative(+1))
+        self._shortcut_prev.activated.connect(partial(self._select_relative, -1))
+        self._shortcut_next.activated.connect(partial(self._select_relative, +1))
 
     @property
     def roots(self) -> list[SidebarNode[TT]]:

--- a/bitcoin_safe/gui/qt/sidebar/sidebar_tree.py
+++ b/bitcoin_safe/gui/qt/sidebar/sidebar_tree.py
@@ -35,7 +35,7 @@ from collections.abc import Callable
 from functools import partial
 from typing import Generic, TypeVar, cast
 
-from bitcoin_safe_lib.gui.qt.signal_tracker import SignalProtocol
+from bitcoin_safe_lib.gui.qt.signal_tracker import SignalProtocol, SignalTracker
 from bitcoin_safe_lib.gui.qt.util import is_dark_mode
 from PyQt6.QtCore import QPoint, Qt, pyqtSignal
 from PyQt6.QtGui import QAction, QColor, QFocusEvent, QIcon, QKeySequence, QPalette, QShortcut
@@ -296,6 +296,7 @@ class SidebarNode(QFrame, Generic[TT]):
         self.indent = indent
         self.parent_node = parent_node
         self.child_nodes: list[SidebarNode[TT]] = []
+        self._parent_signal_tracker = SignalTracker()
         self.stack: QStackedWidget | None = None  # wired by SidebarTree
 
         self.setObjectName(str(id(self)))
@@ -386,11 +387,7 @@ class SidebarNode(QFrame, Generic[TT]):
         if self.stack is not None:
             node._attach_to_stack(self.stack)
 
-        # Wire signals
-        node.closeClicked.connect(self.closeClicked)
-        node.nodeSelected.connect(self._bubble_selected)
-        node.nodeUnSelected.connect(self._bubble_unselected)
-        node.nodeToggled.connect(self._bubble_toggled)
+        node._connect_to_parent_signals(self)
 
         # Insert into layout/list
         self.child_nodes.insert(index, node)
@@ -412,24 +409,17 @@ class SidebarNode(QFrame, Generic[TT]):
             self.stack.removeWidget(self.widget)
         self.stack = None
 
-    def _disconnect_child_signals(self, node: SidebarNode[TT]) -> None:
-        """Disconnect the signal forwarding installed by insertChildNode."""
-        try:
-            node.closeClicked.disconnect(self.closeClicked)
-        except TypeError:
-            pass
-        try:
-            node.nodeSelected.disconnect(self._bubble_selected)
-        except TypeError:
-            pass
-        try:
-            node.nodeUnSelected.disconnect(self._bubble_unselected)
-        except TypeError:
-            pass
-        try:
-            node.nodeToggled.disconnect(self._bubble_toggled)
-        except TypeError:
-            pass
+    def _connect_to_parent_signals(self, parent_node: SidebarNode[TT]) -> None:
+        """Track the signal forwarding this node installs into its parent."""
+        self._parent_signal_tracker.disconnect_all()
+        self._parent_signal_tracker.connect(self.closeClicked, parent_node.closeClicked)
+        self._parent_signal_tracker.connect(self.nodeSelected, parent_node._bubble_selected)
+        self._parent_signal_tracker.connect(self.nodeUnSelected, parent_node._bubble_unselected)
+        self._parent_signal_tracker.connect(self.nodeToggled, parent_node._bubble_toggled)
+
+    def _disconnect_from_parent_signals(self) -> None:
+        """Disconnect any signal forwarding this node previously installed."""
+        self._parent_signal_tracker.disconnect_all()
 
     def removeChildNode(self, node: SidebarNode[TT]) -> None:
         """RemoveChildNode."""
@@ -438,7 +428,7 @@ class SidebarNode(QFrame, Generic[TT]):
         except ValueError:
             return
 
-        self._disconnect_child_signals(node)
+        node._disconnect_from_parent_signals()
         node._detach_from_stack()
 
         # Detaching a node must not overwrite its own visibility state because


### PR DESCRIPTION
## Required

- `pre-commit install` before any commit. If pre-commit wasn't run for all commits, you can squash all commits   `git reset --soft $(git merge-base main HEAD) && git commit -m "squash"` and ensure the squashed commit is properly formatted
- All commits must be signed. If some are not, you can squash all commits   `git reset --soft $(git merge-base main HEAD) && git commit -m "squash"` and ensure the squashed commit is signed
- [ ] UI/Design/Menu changes **were** tested on _macOS_, because _macOS_ creates endless problems.  Optionally attach a screenshot.
 
## Optional

- [ ] Update all translations
- [ ] Appropriate pytests were added
- [ ] Documentation is updated
- [ ] If this PR affects builds or install artifacts, set the `Build-Relevant` label to trigger build workflows
