### PR TITLE
Fix inconsitent spacing in Plugin List

### DIFF
--- a/bitcoin_safe/plugin_framework/plugin_list_widget.py
+++ b/bitcoin_safe/plugin_framework/plugin_list_widget.py
@@ -838,7 +838,6 @@ class PluginListWidget(QWidget):
 
         self.plugins_section_layout = QVBoxLayout(self)
         self.plugins_section_layout.setContentsMargins(0, 0, 0, 0)
-        self.plugins_section_layout.setSpacing(10)
 
         self.plugins_header = SectionHeader(
             self.tr("Plugins"),
@@ -850,7 +849,6 @@ class PluginListWidget(QWidget):
         self.plugins_container = QWidget(self)
         self.plugins_container_layout = QVBoxLayout(self.plugins_container)
         self.plugins_container_layout.setContentsMargins(0, 0, 0, 0)
-        self.plugins_container_layout.setSpacing(4)
         self.plugins_section_layout.addWidget(self.plugins_container)
 
         self.setVisible(False)


### PR DESCRIPTION
## Required

- `pre-commit install` before any commit. If pre-commit wasn't run for all commits, you can squash all commits   `git reset --soft $(git merge-base main HEAD) && git commit -m "squash"` and ensure the squashed commit is properly formatted
- All commits must be signed. If some are not, you can squash all commits   `git reset --soft $(git merge-base main HEAD) && git commit -m "squash"` and ensure the squashed commit is signed
- [ ] UI/Design/Menu changes **were** tested on _macOS_, because _macOS_ creates endless problems.  Optionally attach a screenshot.
 
## Optional

- [ ] Update all translations
- [ ] Appropriate pytests were added
- [ ] Documentation is updated
- [ ] If this PR affects builds or install artifacts, set the `Build-Relevant` label to trigger build workflows
