### PR TITLE
Fix send category auto-selection

### DIFF
--- a/bitcoin_safe/gui/qt/category_manager/category_list.py
+++ b/bitcoin_safe/gui/qt/category_manager/category_list.py
@@ -418,6 +418,26 @@ class CategoryList(MyTreeView[CategoryInfo]):
         items = self.selected_in_column(self.Columns.UTXO_BALANCE)
         return [x.data(MyItemDataRole.ROLE_CLIPBOARD_DATA) for x in items]
 
+    def get_first_funded_category(self) -> str | None:
+        """Get the first category in UI order that has spendable funds."""
+        for row in range(self.proxy.rowCount()):
+            balance_index = self.proxy.index(row, self.Columns.UTXO_BALANCE)
+            balance = self.proxy.data(balance_index, MyItemDataRole.ROLE_CLIPBOARD_DATA)
+            if isinstance(balance, int) and balance > 0:
+                category_index = self.proxy.index(row, self.key_column)
+                category = self.proxy.data(category_index, MyItemDataRole.ROLE_CLIPBOARD_DATA)
+                if isinstance(category, str):
+                    return category
+        return None
+
+    def select_first_funded_category(self, scroll_to_last=False) -> bool:
+        """Select the first category in UI order that has spendable funds."""
+        category = self.get_first_funded_category()
+        if not category:
+            return False
+        self.select_row_by_clipboard(category, scroll_to_last=scroll_to_last)
+        return True
+
     @classmethod
     def from_dump_migration(cls, dct: dict[str, Any]) -> dict[str, Any]:
         """From dump migration."""

--- a/bitcoin_safe/gui/qt/ui_tx/ui_tx_creator.py
+++ b/bitcoin_safe/gui/qt/ui_tx/ui_tx_creator.py
@@ -472,7 +472,6 @@ class UITx_Creator(UITx_Base, BaseSaveableClass):
                     self.clear_ui()
             else:
                 self.clear_ui()
-
         super().showEvent(a0)
 
     def on_fee_rate_change(self, fee_rate: float) -> None:
@@ -637,18 +636,47 @@ class UITx_Creator(UITx_Base, BaseSaveableClass):
         """Reset fee rate."""
         self.column_fee.fee_group.set_spin_fee_value(self.mempool_manager.get_prio_fee_rates()[TxPrio.low])
 
+    def _ensure_default_funded_category_selection(self) -> None:
+        """Select a funded category when the send tab has no saved input selection.
+
+        Example:
+        - Fresh send tab: `TxUiInfos()` -> auto-pick the first funded category.
+        - Restored manual coin selection: do nothing here because `set_ui()` restores the UTXOs.
+        """
+        if not self.wallet:
+            return
+
+        self.category_list.force_full_ui_creation()
+        selected_categories = self.category_list.get_selected_category_infos()
+        if selected_categories:
+            return
+
+        if self.category_list.select_first_funded_category(scroll_to_last=True):
+            return
+
+        self.category_list.select_row_by_clipboard(
+            self.wallet.labels.get_default_category(), scroll_to_last=True
+        )
+
     def clear_ui(self) -> None:
         """Clear ui."""
         if not self.wallet:
             return
+        with BlockChangesSignals([self.category_list]):
+            # Example: "Reset" after selecting an empty default category should behave like a
+            # fresh send tab, so clear the old category selection before `set_ui(TxUiInfos())`.
+            self.category_list.select_rows(
+                [], self.category_list.key_column, role=MyItemDataRole.ROLE_CLIPBOARD_DATA
+            )
+
         with BlockChangesSignals([self.utxo_list]):
             self.additional_outpoints.clear()
             self.utxo_list.set_outpoints(self.get_outpoints())
             self.set_ui(TxUiInfos())
             self.utxo_list.update_content()
-        self.category_list.select_row_by_clipboard(
-            self.wallet.labels.get_default_category(), scroll_to_last=True
-        )
+        # Example: after reset, typing a new recipient address in the same category as the
+        # previous draft should still re-apply that category.
+        self._cache_last_category = None
         self.on_input_changed_and_categories(RefreshCounterKey.UTXO_SELECTION)
         self.hidden_tx_infos = HiddenTxUiInfos()
 
@@ -879,6 +907,9 @@ class UITx_Creator(UITx_Base, BaseSaveableClass):
                 infos, self.utxo_list.get_selected_outpoints(), wallets
             )
             infos.spend_all_utxos = True
+            # Example: after reopening the app, `set_ui(...)` should show the advanced
+            # UTXO picker again for a manual selection instead of switching back to categories.
+            infos.hide_UTXO_selection = False
 
         infos.recipient_read_only = not self.recipients.allow_edit
         infos.utxos_read_only = not self.utxo_list.allow_edit or not self.column_inputs.isEnabled()
@@ -1150,14 +1181,18 @@ class UITx_Creator(UITx_Base, BaseSaveableClass):
 
         self.category_list.force_full_ui_creation()
 
-        categories: set[str] = set()
-        if tx_ui_infos.utxo_dict:
-            # first select the correct categories
-            if self.wallet:
-                for outpoint in tx_ui_infos.utxo_dict.keys():
-                    categories = categories.union(self.wallet.get_categories_for_txid(outpoint.txid_str))
-        elif tx_ui_infos.categories:
-            categories = set(tx_ui_infos.categories)
+        # Restore order:
+        # - Category draft: reselect the saved categories.
+        # - Manual coin selection: reselect the exact UTXOs and keep the matching categories selected
+        #   so the filtered UTXO list still shows those rows after restore.
+        # - Fresh send tab: no saved inputs -> fall back to the first funded category.
+        categories = set(tx_ui_infos.categories or [])
+        if not categories and tx_ui_infos.utxo_dict and self.wallet:
+            for utxo in tx_ui_infos.utxo_dict.values():
+                categories.add(self.wallet.labels.get_category(utxo.address))
+                categories.update(self.wallet.get_categories_for_txid(utxo.outpoint.txid_str))
+        categories = clean_list(list(categories))
+        if tx_ui_infos.categories and not tx_ui_infos.utxo_dict:
             hide_UTXO_selection = True
 
         self.column_inputs.checkBox_manual_coin_select.setChecked(not hide_UTXO_selection)
@@ -1169,9 +1204,12 @@ class UITx_Creator(UITx_Base, BaseSaveableClass):
                 role=MyItemDataRole.ROLE_CLIPBOARD_DATA,
                 scroll_to_last=True,
             )
+        else:
+            self._ensure_default_funded_category_selection()
 
-            # this if statement prevents empty selection on startup, when restoreing the
-            # old tx_ui_infos  (which doesnt contain utxo_dict)
+        if tx_ui_infos.utxo_dict:
+            # Example: restoring a manual selection after reopening the app.
+            # Even if category lookup changes, the exact saved outpoints must win.
             self.utxo_list.select_rows(
                 tx_ui_infos.utxo_dict.keys(),
                 self.utxo_list.key_column,

--- a/tests/gui/qt/test_wallet_send.py
+++ b/tests/gui/qt/test_wallet_send.py
@@ -446,6 +446,34 @@ def test_send_tab_complex_interactions(
         qt_wallet.tabs.setCurrentWidget(qt_wallet.uitx_creator)
         uitx_creator = qt_wallet.uitx_creator
         uitx_creator.enable_refresh_counters()
+        qtbot.waitUntil(
+            lambda: bool(uitx_creator.category_list.get_selected_category_infos()), timeout=10_000
+        )
+        first_funded_category = uitx_creator.category_list.get_first_funded_category()
+        assert first_funded_category is not None
+        selected_category_infos = uitx_creator.category_list.get_selected_category_infos()
+        assert len(selected_category_infos) == 1
+        assert selected_category_infos[0].category == first_funded_category
+        assert selected_category_infos[0].utxo_balance > 0
+        shutter.save(main_window)
+
+        # Reset should ignore a stale empty category selection and go back to the first funded one.
+        default_category = wallet.labels.get_default_category()
+        assert default_category != first_funded_category
+        uitx_creator.category_list.select_row_by_clipboard(default_category)
+        qtbot.waitUntil(
+            lambda: (
+                [info.category for info in uitx_creator.category_list.get_selected_category_infos()]
+                == [default_category]
+            )
+        )
+        uitx_creator.clear_ui()
+        qtbot.waitUntil(
+            lambda: (
+                [info.category for info in uitx_creator.category_list.get_selected_category_infos()]
+                == [first_funded_category]
+            )
+        )
         shutter.save(main_window)
 
         fee_spin = uitx_creator.column_fee.fee_group.spin_fee_rate
@@ -501,6 +529,18 @@ def test_send_tab_complex_interactions(
         )
 
         qtbot.waitUntil(lambda: set(uitx_creator.utxo_list.get_selected_outpoints()) == {selected_outpoint})
+        shutter.save(main_window)
+
+        # App restore stores `get_tx_ui_infos()` and later calls `set_ui(...)` with it again.
+        # This checks the same path without needing a full process restart.
+        saved_tx_ui_infos = uitx_creator.get_tx_ui_infos()
+        uitx_creator.clear_ui()
+        uitx_creator.set_ui(saved_tx_ui_infos)
+        qtbot.waitUntil(lambda: set(uitx_creator.utxo_list.get_selected_outpoints()) == {selected_outpoint})
+        assert uitx_creator.column_inputs.checkBox_manual_coin_select.isChecked()
+        recipients = uitx_creator.recipients
+        recipient_boxes = recipients.get_recipient_group_boxes()
+        fee_spin = uitx_creator.column_fee.fee_group.spin_fee_rate
         shutter.save(main_window)
 
         # Set fee rate explicitly to verify PSBT fee rate propagation.
@@ -607,7 +647,12 @@ def test_send_tab_complex_interactions(
         # Use the category list to tag a recipient address and verify label updates.
         edited_creator.column_inputs.checkBox_manual_coin_select.setChecked(False)
         edited_creator.category_list.select_row_by_clipboard("Private")
-        qtbot.wait(100)
+        qtbot.waitUntil(
+            lambda: (
+                [info.category for info in edited_creator.category_list.get_selected_category_infos()]
+                == ["Private"]
+            )
+        )
         shutter.save(main_window)
 
         recipient_boxes = edited_creator.recipients.get_recipient_group_boxes()
@@ -646,6 +691,14 @@ def test_send_tab_complex_interactions(
         }
         # Category-filtered send should pull inputs from the selected category only.
         assert input_categories == {"KYC"}
+
+        ui_tx_viewer.button_edit_tx.click()
+        qtbot.waitUntil(lambda: qt_wallet.tabs.currentWidget() is qt_wallet.uitx_creator, timeout=10_000)
+        restored_creator = qt_wallet.uitx_creator
+        restored_categories = {
+            info.category for info in restored_creator.category_list.get_selected_category_infos()
+        }
+        assert restored_categories == {"KYC"}
 
         refresh_counts = uitx_creator.refresh_counter_snapshot()
         logger.info("send_tab_refresh_counts=%s", refresh_counts)


### PR DESCRIPTION
## Required

- `pre-commit install` before any commit. If pre-commit wasn't run for all commits, you can squash all commits   `git reset --soft $(git merge-base main HEAD) && git commit -m "squash"` and ensure the squashed commit is properly formatted
- All commits must be signed. If some are not, you can squash all commits   `git reset --soft $(git merge-base main HEAD) && git commit -m "squash"` and ensure the squashed commit is signed
- [ ] UI/Design/Menu changes **were** tested on _macOS_, because _macOS_ creates endless problems.  Optionally attach a screenshot.
 
## Optional

- [ ] Update all translations
- [ ] Appropriate pytests were added
- [ ] Documentation is updated
- [ ] If this PR affects builds or install artifacts, set the `Build-Relevant` label to trigger build workflows
