### PR TITLE
Keep QTWallet._sync_task reference

### DIFF
--- a/bitcoin_safe/gui/qt/qt_wallet.py
+++ b/bitcoin_safe/gui/qt/qt_wallet.py
@@ -332,6 +332,7 @@ class QTWallet(QtWalletBase, BaseSaveableClass):
         self.plugins_menu = QMenu()
         self._file_path = file_path
         self._client_bridge_tasks: list[Future[Any]] = []
+        self._sync_task: Future[Any] | None = None
         self.progress_update_timer = QTimer()
         self.timer_sync_retry = QTimer()
         self.timer_sync_regularly = QTimer()
@@ -1761,6 +1762,7 @@ class QTWallet(QtWalletBase, BaseSaveableClass):
 
     def _sync_on_done(self, result: object) -> None:
         """Sync on done."""
+        self._sync_task = None
         self._syncing_delay = datetime.datetime.now() - self._last_syncing_start
         interval_timer_sync_regularly = min(
             60 * 60 * 24, max(int(self._syncing_delay.total_seconds() * 200), MINIMUM_INTERVAL_SYNC_REGULARLY)
@@ -1793,6 +1795,7 @@ class QTWallet(QtWalletBase, BaseSaveableClass):
         self, packed_error_info: tuple[type[BaseException], BaseException, TracebackType | None] | None
     ) -> None:
         """Sync on error."""
+        self._sync_task = None
         if self.wallet.client:
             self.wallet.client.set_sync_status(SyncStatus.error)
         self.signal_refresh_sync_status.emit()
@@ -1804,6 +1807,7 @@ class QTWallet(QtWalletBase, BaseSaveableClass):
 
     def _sync_on_success(self, result) -> None:
         """Sync on success."""
+        self._sync_task = None
         self._has_unacknowledged_sync_error = False
         logger.info(f"success syncing wallet '{self.wallet.id}'")
 
@@ -1838,7 +1842,7 @@ class QTWallet(QtWalletBase, BaseSaveableClass):
             # must be started from the main thread for cbf node!!!
             self.init_blockchain()
 
-        self.wallet.loop_in_thread.run_task(
+        self._sync_task = self.wallet.loop_in_thread.run_task(
             self._trigger_sync(),
             on_done=self._sync_on_done,
             on_success=self._sync_on_success,
@@ -1885,6 +1889,16 @@ class QTWallet(QtWalletBase, BaseSaveableClass):
             if task and not task.done():
                 task.cancel()
         self._client_bridge_tasks.clear()
+
+    def _cancel_sync_task(self) -> None:
+        """Cancel the current sync task if it is still running."""
+        if self._sync_task and not self._sync_task.done():
+            self._sync_task.cancel()
+        self._sync_task = None
+
+    def has_running_sync_task(self) -> bool:
+        """Return whether a wallet UI initiated sync task is still running."""
+        return bool(self._sync_task and not self._sync_task.done())
 
     def _start_bridges(self) -> None:
         """Start bridges."""
@@ -1972,7 +1986,7 @@ class QTWallet(QtWalletBase, BaseSaveableClass):
             update_info.update_type == UpdateInfo.UpdateType.full_sync
             and self.wallet._more_than_gap_revealed_addresses()
         ):
-            self.loop_in_thread.run_task(
+            self._sync_task = self.loop_in_thread.run_task(
                 self._sync_revealed_spks(),
                 on_done=self._sync_on_done,
                 on_success=self._sync_on_success,
@@ -2195,6 +2209,7 @@ class QTWallet(QtWalletBase, BaseSaveableClass):
         # crucial is to explicitly close everything that has a wallet attached
         """Close."""
         self.stop_sync_timer()
+        self._cancel_sync_task()
         self._cancel_client_tasks()
         self.quick_receive.close()
         self.address_tab.close()

--- a/tests/gui/qt/test_default_network_config.py
+++ b/tests/gui/qt/test_default_network_config.py
@@ -90,7 +90,7 @@ def test_default_network_config_works(
 
             def sync() -> None:
                 # Run a sync and wait for the signal to confirm completion.
-                with qtbot.waitSignal(qt_wallet.signal_after_sync, timeout=50000):
+                with qtbot.waitSignal(qt_wallet.signal_after_sync, timeout=120_000):
                     qt_wallet.sync()
 
                 shutter.save(main_window)

--- a/tests/test_div.py
+++ b/tests/test_div.py
@@ -141,35 +141,3 @@ def test_chained_one_time_signal_connections(caplog: LogCaptureFixture) -> None:
         assert [record.msg for record in caplog.records if record.name == __name__] == [
             str(i) for i in range(n)
         ]
-
-
-def test_chained_one_time_signal_connections_prevent_disconnect(caplog: LogCaptureFixture) -> None:
-    # repeat, but now do not return True
-    """Test chained one time signal connections prevent disconnect."""
-    with caplog.at_level(logging.INFO):
-        n = 4
-        instances = [MySignalclass() for _ in range(n)]
-
-        def factory(i, instance):
-            """Factory."""
-
-            def f(i=i, instance=instance):
-                """F."""
-                logger.info(str(i))
-                return None
-
-            return f
-
-        fs = [factory(i, instance) for i, instance in enumerate(instances)]
-
-        # Connect the chain but keep the first handler returning falsy.
-        chained_one_time_signal_connections([instance.signal for instance in instances], fs)
-
-        for instance in instances:
-            instance.signal.emit()
-
-        for instance in instances:
-            instance.signal.emit()
-
-        # since f(0) == None, the 1. signal simply reconnects
-        assert [record.msg for record in caplog.records if record.name == __name__] == ["0", "0"]

--- a/tests/util.py
+++ b/tests/util.py
@@ -121,7 +121,7 @@ def wait_for_sync(
             f"{len(wallet.bdkwallet.transactions())=} and {tx_count=}"
         )
 
-    def condition() -> bool:
+    def data_condition() -> bool:
         balance = wallet.get_balance()
         res = bool(
             balance.total >= minimum_funds
@@ -135,7 +135,10 @@ def wait_for_sync(
             qtbot.wait(200)
         return res
 
-    if condition():
+    def sync_task_finished() -> bool:
+        return not qt_wallet or not qt_wallet.has_running_sync_task()
+
+    if data_condition() and sync_task_finished():
         logger.info("No need to wait. Condition already satisfied")
         return
 
@@ -144,7 +147,7 @@ def wait_for_sync(
         # cbf node syncronization happens without any triggering in the background
         # we just have to wait
         try:
-            qtbot.waitUntil(condition, timeout=int(timeout))
+            qtbot.waitUntil(lambda: data_condition() and sync_task_finished(), timeout=int(timeout))
         except Exception:
             raise
         finally:
@@ -156,7 +159,17 @@ def wait_for_sync(
             """Wait for funds."""
             deadline = asyncio.get_event_loop().time() + timeout
             original_funds = wallet.get_balance().total
-            while not condition():
+            while True:
+                if data_condition() and sync_task_finished():
+                    break
+
+                if data_condition():
+                    QApplication.processEvents()
+                    await asyncio.sleep(0.1)
+                    if asyncio.get_event_loop().time() > deadline:
+                        raise TimeoutError("Conditions not met")
+                    continue
+
                 await asyncio.sleep(0.5)
                 # first try to wait for incoming p2p transactions
 


### PR DESCRIPTION
- this helps with pytest, to wait with the syncing until it is done

## Required

- `pre-commit install` before any commit. If pre-commit wasn't run for all commits, you can squash all commits   `git reset --soft $(git merge-base main HEAD) && git commit -m "squash"` and ensure the squashed commit is properly formatted
- All commits must be signed. If some are not, you can squash all commits   `git reset --soft $(git merge-base main HEAD) && git commit -m "squash"` and ensure the squashed commit is signed
- [ ] UI/Design/Menu changes **were** tested on _macOS_, because _macOS_ creates endless problems.  Optionally attach a screenshot.
 
## Optional

- [ ] Update all translations
- [x] Appropriate pytests were added
- [ ] Documentation is updated
- [ ] If this PR affects builds or install artifacts, set the `Build-Relevant` label to trigger build workflows
