### PR TITLE
Fail build smoke tests on critical logs

### DIFF
--- a/.github/workflows/build-and-test-mac.yml
+++ b/.github/workflows/build-and-test-mac.yml
@@ -200,12 +200,17 @@ jobs:
         shell: bash
 
 
-      - name: Check for pyzbar log entry in bitcoin_safe.log
+      - name: Check startup log
         run: |
           LOG_PATH="$HOME/Library/Application Support/bitcoin_safe/bitcoin_safe.log"
-          echo "Checking bitcoin_safe.log for 'pyzbar could be loaded successfully' at $LOG_PATH..." | tee -a test_dmg.log
+          echo "Checking startup log at $LOG_PATH..." | tee -a test_dmg.log
           if ! grep -q "pyzbar could be loaded successfully" "$LOG_PATH"; then
             echo "Error: 'pyzbar could be loaded successfully' not found in bitcoin_safe.log" | tee -a test_dmg.log
+            exit 1
+          fi
+          if grep -q "CRITICAL" "$LOG_PATH"; then
+            grep -n "CRITICAL" "$LOG_PATH" | tee -a test_dmg.log || true
+            echo "Error: unexpected CRITICAL entry found in bitcoin_safe.log" | tee -a test_dmg.log
             exit 1
           fi
                 

--- a/.github/workflows/build-appimage-and-test.yml
+++ b/.github/workflows/build-appimage-and-test.yml
@@ -291,6 +291,11 @@ jobs:
             tail -n 100 "$LOG_PATH" || true
             exit 1
           fi
+          if grep -q "CRITICAL" "$LOG_PATH"; then
+            grep -n "CRITICAL" "$LOG_PATH" || true
+            echo "Unexpected CRITICAL entry found in startup log"
+            exit 1
+          fi
           PROCESS_COUNT=$(ps aux | grep -i 'bitcoin' | grep -i 'safe' | grep -v grep | wc -l)
           if [ "$PROCESS_COUNT" -eq 0 ]; then
             echo "Bitcoin Safe process does not appear to be running"

--- a/.github/workflows/build-windows-and-test.yml
+++ b/.github/workflows/build-windows-and-test.yml
@@ -303,6 +303,14 @@ jobs:
               throw "Did not find 'pyzbar could be loaded successfully' in $expectedLogPath"
             }
             Write-Log "Verified 'pyzbar could be loaded successfully' in application log."
+            $criticalMatches = Select-String -Path $resolvedLogPath -Pattern 'CRITICAL' -SimpleMatch
+            if ($criticalMatches) {
+              foreach ($match in $criticalMatches) {
+                Write-Log "CRITICAL log line: $($match.LineNumber): $($match.Line)"
+              }
+              throw "Application log contains CRITICAL entries."
+            }
+            Write-Log "Verified application log does not contain CRITICAL entries."
 
           } finally {
             if ($process -and -not $process.HasExited) {


### PR DESCRIPTION
## Required

- `pre-commit install` before any commit. If pre-commit wasn't run for all commits, you can squash all commits   `git reset --soft $(git merge-base main HEAD) && git commit -m "squash"` and ensure the squashed commit is properly formatted
- All commits must be signed. If some are not, you can squash all commits   `git reset --soft $(git merge-base main HEAD) && git commit -m "squash"` and ensure the squashed commit is signed
- [ ] UI/Design/Menu changes **were** tested on _macOS_, because _macOS_ creates endless problems.  Optionally attach a screenshot.
 
## Optional

- [ ] Update all translations
- [ ] Appropriate pytests were added
- [ ] Documentation is updated
- [ ] If this PR affects builds or install artifacts, set the `Build-Relevant` label to trigger build workflows
