### PR TITLE
Handle prerelease update notifications

### DIFF
--- a/bitcoin_safe/gui/qt/update_notification_bar.py
+++ b/bitcoin_safe/gui/qt/update_notification_bar.py
@@ -36,12 +36,13 @@ import shutil
 import tarfile
 import tempfile
 from pathlib import Path
-from typing import Any, cast
+from typing import cast
 
 from bitcoin_safe_lib.async_tools.loop_in_thread import ExcInfo, LoopInThread, MultipleStrategy
 from bitcoin_safe_lib.gui.qt.signal_tracker import SignalProtocol
 from bitcoin_safe_lib.gui.qt.util import question_dialog
 from bitcoin_safe_lib.util import fast_version
+from packaging.version import InvalidVersion
 from PyQt6.QtCore import Qt, pyqtSignal
 from PyQt6.QtWidgets import QHBoxLayout, QWidget
 
@@ -59,6 +60,7 @@ from ...html_utils import html_f
 from ...signature_manager import (
     Asset,
     GitHubAssetDownloader,
+    GitHubRelease,
     KnownGPGKeys,
     SignatureVerifyer,
 )
@@ -66,6 +68,8 @@ from ...util_os import xdg_open_file
 from .util import Message, MessageType, set_margins
 
 logger = logging.getLogger(__name__)
+
+SHOW_PRERELEASE_UPDATES = False
 
 
 class UpdateNotificationBar(NotificationBar):
@@ -148,6 +152,49 @@ class UpdateNotificationBar(NotificationBar):
             tag = self.assets[-1].tag
             return tag
         return None
+
+    @staticmethod
+    def should_include_prerelease_updates(current_version: str, show_prerelease_updates: bool) -> bool:
+        """Return whether prerelease updates are eligible."""
+        try:
+            current = fast_version(current_version)
+        except InvalidVersion:
+            return show_prerelease_updates
+        return current.is_prerelease or show_prerelease_updates
+
+    @classmethod
+    def select_newest_eligible_release(
+        cls,
+        releases: list[GitHubRelease],
+        current_version: str,
+        show_prerelease_updates: bool,
+    ) -> GitHubRelease | None:
+        """Return the newest eligible release newer than the current version."""
+        try:
+            current = fast_version(current_version)
+        except InvalidVersion:
+            return None
+
+        include_prerelease_updates = cls.should_include_prerelease_updates(
+            current_version=current_version,
+            show_prerelease_updates=show_prerelease_updates,
+        )
+        newest_release: GitHubRelease | None = None
+        newest_version = current
+
+        for release in releases:
+            if release.prerelease and not include_prerelease_updates:
+                continue
+            try:
+                release_version = fast_version(release.tag)
+            except InvalidVersion:
+                continue
+            if release_version <= current or release_version <= newest_version:
+                continue
+            newest_release = release
+            newest_version = release_version
+
+        return newest_release
 
     def is_new_version_available(self) -> bool:
         """Is new version available."""
@@ -371,13 +418,18 @@ class UpdateNotificationBar(NotificationBar):
     def check(self) -> None:
         """Check."""
 
-        async def do() -> Any:
+        async def do() -> list[GitHubRelease]:
             """Do."""
-            return GitHubAssetDownloader(self.key.repository, proxies=self.proxies).get_assets_latest()
+            return GitHubAssetDownloader(self.key.repository, proxies=self.proxies).get_releases()
 
-        def on_success(assets: list[Asset] | None) -> None:
+        def on_success(releases: list[GitHubRelease] | None) -> None:
             """On success."""
-            self.assets = self.get_filtered_assets(assets or [])
+            release = self.select_newest_eligible_release(
+                releases=releases or [],
+                current_version=__version__,
+                show_prerelease_updates=SHOW_PRERELEASE_UPDATES,
+            )
+            self.assets = self.get_filtered_assets(release.assets if release else [])
             self.refresh()
             self.signal_on_success.emit()
 

--- a/bitcoin_safe/signature_manager.py
+++ b/bitcoin_safe/signature_manager.py
@@ -156,6 +156,13 @@ class Asset:
     name: str
 
 
+@dataclass
+class GitHubRelease:
+    tag: str
+    prerelease: bool
+    assets: list[Asset]
+
+
 class GitHubAssetDownloader:
     def __init__(self, repository: str, proxies: dict | None) -> None:
         """Initialize instance."""
@@ -163,21 +170,53 @@ class GitHubAssetDownloader:
         self.proxies = proxies
         logger.debug(f"initialized {self.__class__.__name__}")
 
-    def _get_assets(self, api_url) -> list[Asset]:
-        """Get assets."""
+    @staticmethod
+    def _release_from_payload(payload: dict[str, Any]) -> GitHubRelease:
+        tag = str(payload.get("tag_name", ""))
+        assets_payload = payload.get("assets", [])
+        assets = []
+        if isinstance(assets_payload, list):
+            assets = [
+                Asset(
+                    tag=tag,
+                    url=asset["browser_download_url"],
+                    name=asset["name"],
+                )
+                for asset in assets_payload
+            ]
+        return GitHubRelease(
+            tag=tag,
+            prerelease=bool(payload.get("prerelease", False)),
+            assets=assets,
+        )
+
+    def _get_release(self, api_url: str) -> GitHubRelease | None:
+        """Get a single release."""
         try:
             logger.debug(f"Get assets from {api_url}")
             response = requests.get(api_url, timeout=default_timeout(self.proxies), proxies=self.proxies)
             response.raise_for_status()
-            assets = response.json().get("assets", [])
+            payload = response.json()
+            if not isinstance(payload, dict):
+                return None
+            return self._release_from_payload(payload)
+        except requests.RequestException:
+            logger.error(f"Failed to download: {api_url}")
+            return None
 
+    def _get_releases(self, api_url: str) -> list[GitHubRelease]:
+        """Get releases."""
+        try:
+            logger.debug(f"Get releases from {api_url}")
+            response = requests.get(api_url, timeout=default_timeout(self.proxies), proxies=self.proxies)
+            response.raise_for_status()
+            payload = response.json()
+            if not isinstance(payload, list):
+                return []
             return [
-                Asset(
-                    tag=response.json().get("tag_name", ""),
-                    url=asset["browser_download_url"],
-                    name=asset["name"],
-                )
-                for asset in assets
+                self._release_from_payload(release_payload)
+                for release_payload in payload
+                if isinstance(release_payload, dict) and not bool(release_payload.get("draft", False))
             ]
         except requests.RequestException:
             logger.error(f"Failed to download: {api_url}")
@@ -185,11 +224,21 @@ class GitHubAssetDownloader:
 
     def get_assets_by_tag(self, tag: str) -> list[Asset]:
         """Get assets by tag."""
-        return self._get_assets(f"https://api.github.com/repos/{self.repository}/releases/tags/{tag}")
+        release = self._get_release(f"https://api.github.com/repos/{self.repository}/releases/tags/{tag}")
+        return release.assets if release else []
 
     def get_assets_latest(self) -> list[Asset]:
         """Get assets latest."""
-        return self._get_assets(f"https://api.github.com/repos/{self.repository}/releases/latest")
+        release = self.get_latest_release()
+        return release.assets if release else []
+
+    def get_latest_release(self) -> GitHubRelease | None:
+        """Get latest stable release."""
+        return self._get_release(f"https://api.github.com/repos/{self.repository}/releases/latest")
+
+    def get_releases(self) -> list[GitHubRelease]:
+        """Get releases."""
+        return self._get_releases(f"https://api.github.com/repos/{self.repository}/releases")
 
 
 class SignatureVerifyer:

--- a/tests/gui/qt/conftest.py
+++ b/tests/gui/qt/conftest.py
@@ -30,6 +30,7 @@
 from __future__ import annotations
 
 import datetime
+import os
 import platform
 
 import pytest
@@ -133,10 +134,12 @@ def disable_startup_network_fetches(monkeypatch: pytest.MonkeyPatch) -> None:
         "bitcoin_safe.mempool_manager.MempoolManager.set_data_from_mempoolspace",
         _disable_mempool_fetch,
     )
-    monkeypatch.setattr(
-        "bitcoin_safe.signature_manager.GitHubAssetDownloader.get_releases",
-        _fake_github_releases,
-    )
+    current_test = os.environ.get("PYTEST_CURRENT_TEST", "")
+    if "tests/gui/qt/test_update_notification_bar.py" not in current_test:
+        monkeypatch.setattr(
+            "bitcoin_safe.signature_manager.GitHubAssetDownloader.get_releases",
+            _fake_github_releases,
+        )
 
 
 @pytest.fixture(autouse=True)

--- a/tests/gui/qt/conftest.py
+++ b/tests/gui/qt/conftest.py
@@ -29,7 +29,114 @@
 
 from __future__ import annotations
 
+import datetime
+import platform
+
 import pytest
+
+from bitcoin_safe.constants import MIN_RELAY_FEE
+from bitcoin_safe.signature_manager import Asset, GitHubRelease
+
+
+def _disable_fx_update(self) -> None:
+    self.rates = {
+        "BTC": {"name": "Bitcoin", "unit": "BTC", "value": 1.0, "type": "crypto"},
+        "SATS": {"name": "Satoshis", "unit": "Sats", "value": 100_000_000.0, "type": "crypto"},
+        "USD": {"name": "US Dollar", "unit": "$", "value": 100_000.0, "type": "fiat"},
+        "EUR": {"name": "Euro", "unit": "EUR", "value": 92_000.0, "type": "fiat"},
+    }
+    self.config.rates = self.rates.copy()
+    self._task_set_data = None
+    self.signal_data_updated.emit()
+
+
+def _disable_mempool_fetch(self, force=False) -> None:
+    del force
+    self.data.recommended = {
+        "fastestFee": 12.0,
+        "halfHourFee": 8.0,
+        "hourFee": 5.0,
+        "economyFee": 3.0,
+        "minimumFee": float(MIN_RELAY_FEE),
+    }
+    self.data.mempool_blocks = [
+        {
+            "blockSize": 975_000,
+            "blockVSize": 975_000,
+            "nTx": 1_800,
+            "totalFees": 1_200_000,
+            "medianFee": 12.0,
+            "feeRange": [12.0, 20.0],
+        },
+        {
+            "blockSize": 940_000,
+            "blockVSize": 940_000,
+            "nTx": 1_500,
+            "totalFees": 800_000,
+            "medianFee": 8.0,
+            "feeRange": [8.0, 12.0],
+        },
+        {
+            "blockSize": 910_000,
+            "blockVSize": 910_000,
+            "nTx": 1_200,
+            "totalFees": 500_000,
+            "medianFee": 5.0,
+            "feeRange": [5.0, 8.0],
+        },
+    ]
+    self.data.mempool_dict = {
+        "count": 4_500,
+        "vsize": 2_825_000,
+        "total_fee": 2_500_000,
+        "fee_histogram": [],
+    }
+    self.time_of_data = datetime.datetime.now()
+    self._task_set_data = None
+    self.signal_data_updated.emit()
+
+
+def _fake_github_releases(self) -> list[GitHubRelease]:
+    del self
+    tag = "99.0.0"
+    asset_extension_by_system = {
+        "Darwin": "dmg",
+        "Linux": "AppImage",
+        "Windows": "exe",
+    }
+    asset_architecture = (
+        "arm64" if platform.system() == "Darwin" and "arm" in platform.machine().lower() else "x86_64"
+    )
+    asset_extension = asset_extension_by_system.get(platform.system(), "AppImage")
+    asset_name = f"bitcoin-safe-{tag}-{asset_architecture}.{asset_extension}"
+    return [
+        GitHubRelease(
+            tag=tag,
+            prerelease=False,
+            assets=[
+                Asset(
+                    tag=tag,
+                    url=f"https://example.com/{asset_name}",
+                    name=asset_name,
+                )
+            ],
+        )
+    ]
+
+
+@pytest.fixture(autouse=True)
+def disable_startup_network_fetches(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep GUI tests deterministic by disabling live startup HTTP fetches."""
+
+    monkeypatch.setattr("bitcoin_safe.fx.FX.update", _disable_fx_update)
+    monkeypatch.setattr(
+        "bitcoin_safe.mempool_manager.MempoolManager.set_data_from_mempoolspace",
+        _disable_mempool_fetch,
+    )
+    monkeypatch.setattr(
+        "bitcoin_safe.signature_manager.GitHubAssetDownloader.get_releases",
+        _fake_github_releases,
+    )
 
 
 @pytest.fixture(autouse=True)

--- a/tests/gui/qt/conftest.py
+++ b/tests/gui/qt/conftest.py
@@ -55,9 +55,9 @@ def _disable_mempool_fetch(self, force=False) -> None:
     del force
     self.data.recommended = {
         "fastestFee": 12.0,
-        "halfHourFee": 8.0,
-        "hourFee": 5.0,
-        "economyFee": 3.0,
+        "halfHourFee": 4.0,
+        "hourFee": float(MIN_RELAY_FEE),
+        "economyFee": float(MIN_RELAY_FEE),
         "minimumFee": float(MIN_RELAY_FEE),
     }
     self.data.mempool_blocks = [
@@ -74,16 +74,16 @@ def _disable_mempool_fetch(self, force=False) -> None:
             "blockVSize": 940_000,
             "nTx": 1_500,
             "totalFees": 800_000,
-            "medianFee": 8.0,
-            "feeRange": [8.0, 12.0],
+            "medianFee": 4.0,
+            "feeRange": [4.0, 12.0],
         },
         {
             "blockSize": 910_000,
             "blockVSize": 910_000,
             "nTx": 1_200,
             "totalFees": 500_000,
-            "medianFee": 5.0,
-            "feeRange": [5.0, 8.0],
+            "medianFee": float(MIN_RELAY_FEE),
+            "feeRange": [float(MIN_RELAY_FEE), 4.0],
         },
     ]
     self.data.mempool_dict = {

--- a/tests/gui/qt/test_update_notification_bar.py
+++ b/tests/gui/qt/test_update_notification_bar.py
@@ -1,0 +1,145 @@
+#
+# Bitcoin Safe
+# Copyright (C) 2026 Andreas Griffin
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of version 3 of the GNU General Public License as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see https://www.gnu.org/licenses/gpl-3.0.html
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+# BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+# ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
+from __future__ import annotations
+
+import pytest
+
+from bitcoin_safe.gui.qt.update_notification_bar import UpdateNotificationBar
+from bitcoin_safe.signature_manager import Asset, GitHubAssetDownloader, GitHubRelease
+
+
+class _MockResponse:
+    def __init__(self, json_payload: list[dict], status_code: int = 200) -> None:
+        self.status_code = status_code
+        self._json_payload = json_payload
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            raise RuntimeError(f"HTTP error: {self.status_code}")
+
+    def json(self) -> list[dict]:
+        return self._json_payload
+
+
+def _release(tag: str, prerelease: bool) -> GitHubRelease:
+    return GitHubRelease(
+        tag=tag,
+        prerelease=prerelease,
+        assets=[
+            Asset(
+                tag=tag,
+                url=f"https://example.com/{tag}",
+                name=f"bitcoin-safe-{tag}-x86_64.AppImage",
+            )
+        ],
+    )
+
+
+def test_select_newest_eligible_release_ignores_prerelease_for_stable_versions() -> None:
+    release = UpdateNotificationBar.select_newest_eligible_release(
+        releases=[_release("1.1.0rc1", prerelease=True), _release("1.0.1", prerelease=False)],
+        current_version="1.0.0",
+        show_prerelease_updates=False,
+    )
+
+    assert release
+    assert release.tag == "1.0.1"
+
+
+def test_select_newest_eligible_release_can_include_prerelease_for_stable_versions() -> None:
+    release = UpdateNotificationBar.select_newest_eligible_release(
+        releases=[_release("1.1.0rc1", prerelease=True), _release("1.0.1", prerelease=False)],
+        current_version="1.0.0",
+        show_prerelease_updates=True,
+    )
+
+    assert release
+    assert release.tag == "1.1.0rc1"
+
+
+def test_select_newest_eligible_release_includes_prerelease_for_dev_versions() -> None:
+    release = UpdateNotificationBar.select_newest_eligible_release(
+        releases=[_release("1.0.0rc1", prerelease=True)],
+        current_version="1.0.0.dev1",
+        show_prerelease_updates=False,
+    )
+
+    assert release
+    assert release.tag == "1.0.0rc1"
+
+
+def test_select_newest_eligible_release_treats_final_release_as_newer_than_rc() -> None:
+    release = UpdateNotificationBar.select_newest_eligible_release(
+        releases=[_release("1.0.0", prerelease=False), _release("1.0.0rc2", prerelease=True)],
+        current_version="1.0.0rc1",
+        show_prerelease_updates=False,
+    )
+
+    assert release
+    assert release.tag == "1.0.0"
+
+
+def test_select_newest_eligible_release_returns_none_without_eligible_update() -> None:
+    release = UpdateNotificationBar.select_newest_eligible_release(
+        releases=[_release("1.1.0rc1", prerelease=True), _release("1.0.0", prerelease=False)],
+        current_version="1.0.0",
+        show_prerelease_updates=False,
+    )
+
+    assert release is None
+
+
+def test_get_releases_ignores_drafts(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_get(url: str, timeout: int, proxies: dict | None) -> _MockResponse:
+        del url, timeout, proxies
+        return _MockResponse(
+            [
+                {
+                    "tag_name": "1.0.1",
+                    "prerelease": False,
+                    "draft": False,
+                    "assets": [{"name": "bitcoin-safe-1.0.1-x86_64.AppImage", "browser_download_url": "ok"}],
+                },
+                {
+                    "tag_name": "1.1.0rc1",
+                    "prerelease": True,
+                    "draft": True,
+                    "assets": [
+                        {"name": "bitcoin-safe-1.1.0rc1-x86_64.AppImage", "browser_download_url": "skip"}
+                    ],
+                },
+            ]
+        )
+
+    monkeypatch.setattr("bitcoin_safe.signature_manager.requests.get", fake_get)
+
+    releases = GitHubAssetDownloader("andreasgriffin/bitcoin-safe", proxies=None).get_releases()
+
+    assert [release.tag for release in releases] == ["1.0.1"]

--- a/tests/gui/qt/test_wallet_features.py
+++ b/tests/gui/qt/test_wallet_features.py
@@ -62,7 +62,7 @@ from bitcoin_safe.gui.qt.register_multisig import (
 from bitcoin_safe.gui.qt.settings import Settings
 from bitcoin_safe.hardware_signers import DescriptorQrExportTypes, HardwareSigners
 from bitcoin_safe.signals import Signals, WalletFunctions
-from bitcoin_safe.signature_manager import Asset
+from bitcoin_safe.signature_manager import Asset, GitHubRelease
 from bitcoin_safe.util import filename_clean
 from bitcoin_safe.wallet import Wallet
 
@@ -176,12 +176,18 @@ def test_wallet_features_multisig(
     asset_extension = asset_extension_by_system.get(platform.system(), "AppImage")
 
     monkeypatch.setattr(
-        "bitcoin_safe.gui.qt.update_notification_bar.GitHubAssetDownloader.get_assets_latest",
+        "bitcoin_safe.gui.qt.update_notification_bar.GitHubAssetDownloader.get_releases",
         lambda self: [
-            Asset(
+            GitHubRelease(
                 tag="999.0.0",
-                url=f"https://example.com/bitcoin-safe-999.0.0-{asset_architecture}.{asset_extension}",
-                name=f"bitcoin-safe-999.0.0-{asset_architecture}.{asset_extension}",
+                prerelease=False,
+                assets=[
+                    Asset(
+                        tag="999.0.0",
+                        url=f"https://example.com/bitcoin-safe-999.0.0-{asset_architecture}.{asset_extension}",
+                        name=f"bitcoin-safe-999.0.0-{asset_architecture}.{asset_extension}",
+                    )
+                ],
             )
         ],
     )


### PR DESCRIPTION
- if the currently running app is a pre-release it will notify of newer pre-releases
- monkeypatch live requests (mempool, github, coingecko) during pytest

tagging: @design-rrr 

## Required

- `pre-commit install` before any commit. If pre-commit wasn't run for all commits, you can squash all commits   `git reset --soft $(git merge-base main HEAD) && git commit -m "squash"` and ensure the squashed commit is properly formatted
- All commits must be signed. If some are not, you can squash all commits   `git reset --soft $(git merge-base main HEAD) && git commit -m "squash"` and ensure the squashed commit is signed
- [ ] UI/Design/Menu changes **were** tested on _macOS_, because _macOS_ creates endless problems.  Optionally attach a screenshot.
 
## Optional

- [ ] Update all translations
- [ ] Appropriate pytests were added
- [ ] Documentation is updated
- [ ] If this PR affects builds or install artifacts, set the `Build-Relevant` label to trigger build workflows
