### PR TITLE
Custom: make 2-o-3 defaults (instead of 3-o-5)

### DIFF
--- a/bitcoin_safe/gui/qt/main.py
+++ b/bitcoin_safe/gui/qt/main.py
@@ -2442,7 +2442,7 @@ class MainWindow(UnlockableMainWindow):
     def click_custom_signature(self) -> None:
         """Click custom signature."""
         self.open_qtprotowallet_setup(
-            (3, 5),
+            (2, 3),
             wallet_id=self.preferred_wallet_id(self.welcome_screen.wallet_name),
             show_tutorial=False,
         )

--- a/tests/gui/qt/test_setup_wallet_custom.py
+++ b/tests/gui/qt/test_setup_wallet_custom.py
@@ -204,13 +204,13 @@ def test_custom_wallet_setup_custom_single_sig(
             shutter.save(main_window)
 
             # Verify the default 3-of-5 multisig configuration for the fixture.
-            assert qt_protowallet.wallet_descriptor_ui.spin_req.value() == 3
-            assert qt_protowallet.wallet_descriptor_ui.spin_signers.value() == 5
+            assert qt_protowallet.wallet_descriptor_ui.spin_req.value() == 2
+            assert qt_protowallet.wallet_descriptor_ui.spin_signers.value() == 3
             assert (
                 qt_protowallet.wallet_descriptor_ui.comboBox_address_type.currentData() == AddressTypes.p2wsh
             )
             assert qt_protowallet.wallet_descriptor_ui.spin_gap.value() == 20
-            assert qt_protowallet.wallet_descriptor_ui.keystore_uis.count() == 5
+            assert qt_protowallet.wallet_descriptor_ui.keystore_uis.count() == 3
 
             shutter.save(main_window)
             check_consistent()

--- a/tests/gui/qt/test_wallet_features.py
+++ b/tests/gui/qt/test_wallet_features.py
@@ -338,13 +338,13 @@ def test_wallet_features_multisig(
             shutter.save(main_window)
 
             # Verify the default 3-of-5 multisig configuration for the fixture.
-            assert qt_protowallet.wallet_descriptor_ui.spin_req.value() == 3
-            assert qt_protowallet.wallet_descriptor_ui.spin_signers.value() == 5
+            assert qt_protowallet.wallet_descriptor_ui.spin_req.value() == 2
+            assert qt_protowallet.wallet_descriptor_ui.spin_signers.value() == 3
             assert (
                 qt_protowallet.wallet_descriptor_ui.comboBox_address_type.currentData() == AddressTypes.p2wsh
             )
             assert qt_protowallet.wallet_descriptor_ui.spin_gap.value() == 20
-            assert qt_protowallet.wallet_descriptor_ui.keystore_uis.count() == 5
+            assert qt_protowallet.wallet_descriptor_ui.keystore_uis.count() == 3
 
             shutter.save(main_window)
             check_consistent()


### PR DESCRIPTION
suggestion from @design-rrr 

## Required

- `pre-commit install` before any commit. If pre-commit wasn't run for all commits, you can squash all commits   `git reset --soft $(git merge-base main HEAD) && git commit -m "squash"` and ensure the squashed commit is properly formatted
- All commits must be signed. If some are not, you can squash all commits   `git reset --soft $(git merge-base main HEAD) && git commit -m "squash"` and ensure the squashed commit is signed
- [ ] UI/Design/Menu changes **were** tested on _macOS_, because _macOS_ creates endless problems.  Optionally attach a screenshot.
 
## Optional

- [ ] Update all translations
- [ ] Appropriate pytests were added
- [ ] Documentation is updated
- [ ] If this PR affects builds or install artifacts, set the `Build-Relevant` label to trigger build workflows
