### PR TITLE
Fix toolbar language refresh after language switch

### DIFF
--- a/bitcoin_safe/gui/qt/address_list.py
+++ b/bitcoin_safe/gui/qt/address_list.py
@@ -1110,6 +1110,13 @@ class AddressListWithToolbar(TreeViewWithToolbar):
             self.category_combobox.currentText() in self.category_core.wallet.labels.categories
         )
 
+    def _update_filter_combobox_texts(self) -> None:
+        """Refresh translated filter labels after a language switch."""
+        for index, addr_type in enumerate(AddressTypeFilter):
+            self.change_button.setItemText(index, addr_type.ui_text())
+        for index, addr_usage_state in enumerate(AddressUsageStateFilter):
+            self.used_button.setItemText(index, addr_usage_state.ui_text())
+
     def update_with_filter(self, update_filter: UpdateFilter):
         """Update with filter."""
         self.updateUi()
@@ -1119,6 +1126,7 @@ class AddressListWithToolbar(TreeViewWithToolbar):
         super().updateUi()
 
         self.set_visibilities()
+        self._update_filter_combobox_texts()
 
         for action in list(self.menu.actions()):
             sub = action.menu()

--- a/bitcoin_safe/gui/qt/bitcoin_quick_receive.py
+++ b/bitcoin_safe/gui/qt/bitcoin_quick_receive.py
@@ -66,11 +66,7 @@ class BitcoinQuickReceive(
 
         # signals
         self.wallet_signals.updated.connect(self.update_content)
-        self.wallet_signals.language_switch.connect(self.refresh_all)
-
-    def refresh_all(self):
-        """Refresh all."""
-        self.update_content(UpdateFilter(refresh_all=True))
+        self.signals_min.language_switch.connect(self.updateUi)
 
     def set_address(self, category: str, address_info: bdk.AddressInfo) -> ReceiveGroup:
         """Set address."""

--- a/bitcoin_safe/gui/qt/my_treeview.py
+++ b/bitcoin_safe/gui/qt/my_treeview.py
@@ -1757,6 +1757,7 @@ class TreeViewWithToolbar(SearchableTab, BaseSaveableClass):
         self.search_edit.setPlaceholderText(translate("mytreeview", "Type to filter"))
         self.action_export_as_csv.setText(translate("mytreeview", "Export as CSV"))
         self.menu_hiddden_columns.setTitle(translate("mytreeview", "Visible columns"))
+        self.fill_menu_hiddden_columns()
 
     def close(self) -> bool:
         """Close."""

--- a/bitcoin_safe/gui/qt/qr_components/quick_receive.py
+++ b/bitcoin_safe/gui/qt/qr_components/quick_receive.py
@@ -53,6 +53,7 @@ from PyQt6.QtWidgets import (
 
 from bitcoin_safe.gui.qt.qr_components.square_buttons import FlatSquareButton
 from bitcoin_safe.gui.qt.util import do_copy, set_translucent, svg_tools
+from bitcoin_safe.i18n import translate
 from bitcoin_safe.pythonbdk_types import AddressInfoMin
 
 from ..util import to_color_name
@@ -326,8 +327,8 @@ class QuickReceive(QWidget):
         self.manage_categories_button.setIcon(svg_tools.get_QIcon("bi--gear.svg"))
         self.manage_categories_button.setCursor(Qt.CursorShape.PointingHandCursor)
         self.manage_categories_button.setFlat(True)
-        self.manage_categories_button.setText(self.tr("Manage Categories"))
-        self.manage_categories_button.setToolTip(self.tr("Open the category manager"))
+        self.manage_categories_button.setText(translate("QuickReceive", "Manage Categories"))
+        self.manage_categories_button.setToolTip(translate("QuickReceive", "Open the category manager"))
         self.manage_categories_button.clicked.connect(self.signal_manage_categories_requested.emit)
         header_layout.addWidget(self.manage_categories_button)
 
@@ -395,9 +396,9 @@ class QuickReceive(QWidget):
 
     def updateUi(self):
         """UpdateUi."""
-        self.label_title.setText(self.tr("Quick Receive"))
-        self.manage_categories_button.setText(self.tr("Manage Categories"))
-        self.manage_categories_button.setToolTip(self.tr("Open the category manager"))
+        self.label_title.setText(translate("QuickReceive", "Quick Receive"))
+        self.manage_categories_button.setText(translate("QuickReceive", "Manage Categories"))
+        self.manage_categories_button.setToolTip(translate("QuickReceive", "Open the category manager"))
         self.add_category_button.updateUi()
         for gb in self.group_boxes:
             gb.updateUi()


### PR DESCRIPTION
## Required

- `pre-commit install` before any commit. If pre-commit wasn't run for all commits, you can squash all commits   `git reset --soft $(git merge-base main HEAD) && git commit -m "squash"` and ensure the squashed commit is properly formatted
- All commits must be signed. If some are not, you can squash all commits   `git reset --soft $(git merge-base main HEAD) && git commit -m "squash"` and ensure the squashed commit is signed
- [ ] UI/Design/Menu changes **were** tested on _macOS_, because _macOS_ creates endless problems.  Optionally attach a screenshot.
 
## Optional

- [ ] Update all translations
- [ ] Appropriate pytests were added
- [ ] Documentation is updated
- [ ] If this PR affects builds or install artifacts, set the `Build-Relevant` label to trigger build workflows
