### PR TITLE
Descriptor UI:  Discard button on the left

### DIFF
--- a/bitcoin_safe/gui/qt/descriptor_ui.py
+++ b/bitcoin_safe/gui/qt/descriptor_ui.py
@@ -48,8 +48,10 @@ from PyQt6.QtWidgets import (
     QLabel,
     QLineEdit,
     QMessageBox,
+    QPushButton,
     QSizePolicy,
     QSpinBox,
+    QStyle,
     QVBoxLayout,
     QWidget,
 )
@@ -621,19 +623,21 @@ class DescriptorUI(QWidget):
         return None
 
     def create_button_bar(self) -> QDialogButtonBox:
-        # Create buttons and layout
         """Create button bar."""
-        self.button_box = QDialogButtonBox(
-            QDialogButtonBox.StandardButton.Apply | QDialogButtonBox.StandardButton.Discard
-        )
-        if _button := self.button_box.button(QDialogButtonBox.StandardButton.Apply):
-            _button.clicked.connect(self.signal_qtwallet_apply_setting_changes.emit)
-        if _button := self.button_box.button(QDialogButtonBox.StandardButton.Discard):
-            _button.clicked.connect(self.signal_qtwallet_cancel_setting_changes.emit)
-        if _button := self.button_box.button(QDialogButtonBox.StandardButton.Discard):
-            _button.clicked.connect(self.signal_qtwallet_cancel_wallet_creation.emit)
+        self.button_box = QDialogButtonBox(self)
+        style = self.button_box.style() or QStyle()
+        discard_button = QPushButton(self.tr("Discard"), self.button_box)
+        discard_button.setIcon(style.standardIcon(QStyle.StandardPixmap.SP_DialogDiscardButton))
+        discard_button.clicked.connect(self.signal_qtwallet_cancel_setting_changes.emit)
+        discard_button.clicked.connect(self.signal_qtwallet_cancel_wallet_creation.emit)
+        self.button_box.addButton(discard_button, QDialogButtonBox.ButtonRole.ResetRole)
 
-        self._layout.addWidget(self.button_box, 0, Qt.AlignmentFlag.AlignRight)
+        apply_button = QPushButton(self.tr("Apply"), self.button_box)
+        apply_button.setIcon(style.standardIcon(QStyle.StandardPixmap.SP_DialogApplyButton))
+        apply_button.clicked.connect(self.signal_qtwallet_apply_setting_changes.emit)
+        self.button_box.addButton(apply_button, QDialogButtonBox.ButtonRole.AcceptRole)
+
+        self._layout.addWidget(self.button_box)
         return self.button_box
 
     def close(self):

--- a/tests/gui/qt/helpers.py
+++ b/tests/gui/qt/helpers.py
@@ -54,6 +54,7 @@ from PyQt6.QtCore import QTimer
 from PyQt6.QtGui import QAction
 from PyQt6.QtTest import QTest
 from PyQt6.QtWidgets import (
+    QAbstractButton,
     QApplication,
     QDialogButtonBox,
     QFileDialog,
@@ -230,9 +231,7 @@ def setup_single_sig_wallet(
     save_wallet(
         test_config=test_config,
         wallet_name=wallet_name,
-        save_button=qt_protowallet.wallet_descriptor_ui.button_box.button(
-            QDialogButtonBox.StandardButton.Apply
-        ),
+        save_button=get_apply_button(qt_protowallet.wallet_descriptor_ui.button_box),
     )
 
     qt_wallet = main_window.tab_wallets.root.findNodeByTitle(wallet_name).data
@@ -441,7 +440,7 @@ def type_text_in_edit(text: str, edit: QLineEdit | QTextEdit) -> None:
 def save_wallet(
     test_config: UserConfig,
     wallet_name: str,
-    save_button: QPushButton,
+    save_button: QAbstractButton,
 ) -> Path:
     """Save wallet."""
     wallet_file = Path(test_config.config_dir) / f"{wallet_name}.wallet"
@@ -456,6 +455,18 @@ def save_wallet(
 
         mock_open.assert_called_once()
     return wallet_file
+
+
+def get_apply_button(button_box: QDialogButtonBox) -> QAbstractButton:
+    """Return the apply button for both standard and custom button-box layouts."""
+    if button := button_box.button(QDialogButtonBox.StandardButton.Apply):
+        return button
+
+    for candidate in button_box.buttons():
+        if button_box.buttonRole(candidate) == QDialogButtonBox.ButtonRole.AcceptRole:
+            return candidate
+
+    raise AssertionError("Apply button not found in dialog button box")
 
 
 def close_wallet(

--- a/tests/gui/qt/test_address_list.py
+++ b/tests/gui/qt/test_address_list.py
@@ -53,6 +53,7 @@ from .helpers import (
     Shutter,
     do_modal_click,
     fund_wallet,
+    get_apply_button,
     main_window_context,
     save_wallet,
     select_manual_entry_signer,
@@ -130,9 +131,7 @@ def test_address_list_label_filter_and_utxo_selection(
         save_wallet(
             test_config=test_config,
             wallet_name=wallet_id,
-            save_button=qt_protowallet.wallet_descriptor_ui.button_box.button(
-                QDialogButtonBox.StandardButton.Apply
-            ),
+            save_button=get_apply_button(qt_protowallet.wallet_descriptor_ui.button_box),
         )
 
         # Open the freshly created wallet and navigate to the address tab.

--- a/tests/gui/qt/test_history_range.py
+++ b/tests/gui/qt/test_history_range.py
@@ -52,6 +52,7 @@ from ...util import wait_for_sync
 from .helpers import (
     Shutter,
     do_modal_click,
+    get_apply_button,
     main_window_context,
     save_wallet,
     select_manual_entry_signer,
@@ -103,9 +104,7 @@ def test_history_range_coupling(
         save_wallet(
             test_config=test_config,
             wallet_name=wallet_id,
-            save_button=qt_protowallet.wallet_descriptor_ui.button_box.button(
-                QDialogButtonBox.StandardButton.Apply
-            ),
+            save_button=get_apply_button(qt_protowallet.wallet_descriptor_ui.button_box),
         )
 
         qt_wallet = main_window.tab_wallets.root.findNodeByTitle(wallet_id).data

--- a/tests/gui/qt/test_setup_wallet_custom.py
+++ b/tests/gui/qt/test_setup_wallet_custom.py
@@ -55,6 +55,7 @@ from .helpers import (
     Shutter,
     close_wallet,
     do_modal_click,
+    get_apply_button,
     main_window_context,
     save_wallet,
     select_manual_entry_signer,
@@ -260,9 +261,7 @@ def test_custom_wallet_setup_custom_single_sig(
             save_wallet(
                 test_config=test_config,
                 wallet_name=wallet_name,
-                save_button=qt_protowallet.wallet_descriptor_ui.button_box.button(
-                    QDialogButtonBox.StandardButton.Apply
-                ),
+                save_button=get_apply_button(qt_protowallet.wallet_descriptor_ui.button_box),
             )
 
             assert len(main_window.tab_wallets.root.child_nodes) == 1, "there should be only 1 wallet open"
@@ -359,9 +358,7 @@ def test_custom_wallet_setup_custom_single_sig(
 
             with patch("bitcoin_safe.gui.qt.qt_wallet.Message") as mock_message:
                 do_modal_click(
-                    qt_wallet.wallet_descriptor_ui.button_box.button(
-                        QDialogButtonBox.StandardButton.Apply
-                    ).click,
+                    get_apply_button(qt_wallet.wallet_descriptor_ui.button_box).click,
                     on_proceed_question,
                     qtbot,
                     cls=QMessageBox,

--- a/tests/gui/qt/test_wallet_features.py
+++ b/tests/gui/qt/test_wallet_features.py
@@ -76,6 +76,7 @@ from .helpers import (
     Shutter,
     close_wallet,
     do_modal_click,
+    get_apply_button,
     main_window_context,
     running_on_github,
     save_wallet,
@@ -396,10 +397,7 @@ def test_wallet_features_multisig(
             set_mnemonic(0)
             set_mnemonic(1)
 
-            save_button = qt_protowallet.wallet_descriptor_ui.button_box.button(
-                QDialogButtonBox.StandardButton.Apply
-            )
-            assert save_button
+            save_button = get_apply_button(qt_protowallet.wallet_descriptor_ui.button_box)
             wallet_file = save_wallet(
                 test_config=test_config,
                 wallet_name=wallet_name,

--- a/tests/gui/qt/test_wallet_rbf_cpfp.py
+++ b/tests/gui/qt/test_wallet_rbf_cpfp.py
@@ -53,6 +53,7 @@ from .helpers import (
     close_wallet,
     do_modal_click,
     fund_wallet,
+    get_apply_button,
     main_window_context,
     save_wallet,
     select_manual_entry_signer,
@@ -113,9 +114,7 @@ def test_rbf_cpfp_flow(
         save_wallet(
             test_config=test_config,
             wallet_name=wallet_name,
-            save_button=qt_protowallet.wallet_descriptor_ui.button_box.button(
-                QDialogButtonBox.StandardButton.Apply
-            ),
+            save_button=get_apply_button(qt_protowallet.wallet_descriptor_ui.button_box),
         )
 
         qt_wallet = main_window.tab_wallets.root.findNodeByTitle(wallet_name).data


### PR DESCRIPTION
## Required

- `pre-commit install` before any commit. If pre-commit wasn't run for all commits, you can squash all commits   `git reset --soft $(git merge-base main HEAD) && git commit -m "squash"` and ensure the squashed commit is properly formatted
- All commits must be signed. If some are not, you can squash all commits   `git reset --soft $(git merge-base main HEAD) && git commit -m "squash"` and ensure the squashed commit is signed
- [x] UI/Design/Menu changes **were** tested on _macOS_, because _macOS_ creates endless problems.  Optionally attach a screenshot.
 
## Optional

- [ ] Update all translations
- [ ] Appropriate pytests were added
- [ ] Documentation is updated
- [ ] If this PR affects builds or install artifacts, set the `Build-Relevant` label to trigger build workflows
