### PR TITLE
Add reproducibility workflow for build artifacts

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,3 +10,4 @@
 - [ ] Appropriate pytests were added
 - [ ] Documentation is updated
 - [ ] If this PR affects builds or install artifacts, set the `Build-Relevant` label to trigger build workflows
+- [ ] If this PR affects reproducible build outputs, set the `Reproducibility-Relevant` label to trigger the checksum comparison workflow

--- a/.github/workflows/build-and-test-mac.yml
+++ b/.github/workflows/build-and-test-mac.yml
@@ -10,12 +10,30 @@ on:
         description: 'Enter the commit hash to build (leave empty to use the default branch or the branch that triggered the workflow)'
         required: false
         type: string
+      artifact_name_prefix:
+        description: 'Optional prefix for uploaded artifact names'
+        required: false
+        default: ''
+        type: string
       skip_build_and_test_release_tag:
         description: 'Release tag to download prebuilt macOS artifacts instead of building (leave empty to build)'
         required: false
         default: ''
         type: string
   workflow_call:
+    inputs:
+      commitHash:
+        required: false
+        type: string
+        default: ''
+      artifact_name_prefix:
+        required: false
+        type: string
+        default: ''
+      skip_build_and_test_release_tag:
+        required: false
+        type: string
+        default: ''
 
 jobs:
   build:
@@ -41,33 +59,33 @@ jobs:
 
       # 2) if a SHA was provided, fetch it and switch to it
       - name: Fetch and checkout custom commit
-        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.commitHash != '' }}
+        if: ${{ inputs.commitHash != '' }}
         run: |
           # this will succeed as long as the commit is reachable from ANY branch on the remote
-          git fetch origin ${{ github.event.inputs.commitHash }}
-          git checkout ${{ github.event.inputs.commitHash }}           
+          git fetch origin ${{ inputs.commitHash }}
+          git checkout ${{ inputs.commitHash }}
 
       # Use the build path for all non-dispatch events, or dispatch events that did not request a prebuilt release download.
       # When skip_build_and_test_release_tag is non-empty on workflow_dispatch, the release-download path is used instead.
       - name: Set up Python environment
-        if: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.skip_build_and_test_release_tag == '' }}
+        if: ${{ github.event_name != 'workflow_dispatch' || inputs.skip_build_and_test_release_tag == '' }}
         uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 
       - name: Install Python dependencies
-        if: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.skip_build_and_test_release_tag == '' }}
+        if: ${{ github.event_name != 'workflow_dispatch' || inputs.skip_build_and_test_release_tag == '' }}
         run: |
           python -m pip install --upgrade pip
           pip install poetry
           poetry install
 
       - name: Run build script
-        if: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.skip_build_and_test_release_tag == '' }}
+        if: ${{ github.event_name != 'workflow_dispatch' || inputs.skip_build_and_test_release_tag == '' }}
         run: poetry run python tools/build.py --targets mac --commit None
 
       - name: Check for DMG file
-        if: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.skip_build_and_test_release_tag == '' }}
+        if: ${{ github.event_name != 'workflow_dispatch' || inputs.skip_build_and_test_release_tag == '' }}
         run: |
           if [ -z "$(find dist -type f -name '*.dmg')" ]; then
             echo "DMG file is missing"
@@ -75,10 +93,10 @@ jobs:
           fi
 
       - name: Upload DMG Files from dist/
-        if: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.skip_build_and_test_release_tag == '' }}
+        if: ${{ github.event_name != 'workflow_dispatch' || inputs.skip_build_and_test_release_tag == '' }}
         uses: actions/upload-artifact@v7
         with:
-          name: mac-artifact-${{ matrix.artifact_name }}
+          name: ${{ inputs.artifact_name_prefix }}mac-artifact-${{ matrix.artifact_name }}
           path: dist/*.dmg
 
   test:
@@ -95,20 +113,20 @@ jobs:
     runs-on: ${{ matrix.runner }}
     steps:
       - name: Download DMG Artifact for ${{ matrix.arch }}
-        if: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.skip_build_and_test_release_tag == '' }}
+        if: ${{ github.event_name != 'workflow_dispatch' || inputs.skip_build_and_test_release_tag == '' }}
         uses: actions/download-artifact@v7
         with:
-          name: mac-artifact-${{ matrix.artifact_name }}
+          name: ${{ inputs.artifact_name_prefix }}mac-artifact-${{ matrix.artifact_name }}
           path: dmgs
 
       - name: Download release DMG for ${{ matrix.arch }}
-        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.skip_build_and_test_release_tag != '' }}
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.skip_build_and_test_release_tag != '' }}
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           mkdir -p dmgs
-          gh release download "${{ github.event.inputs.skip_build_and_test_release_tag }}" \
+          gh release download "${{ inputs.skip_build_and_test_release_tag }}" \
             --dir dmgs \
             --repo "${{ github.repository }}" \
             --pattern "*-${{ matrix.arch }}.dmg"

--- a/.github/workflows/build-appimage-and-test.yml
+++ b/.github/workflows/build-appimage-and-test.yml
@@ -12,12 +12,39 @@ on:
         description: 'Enter the commit hash to build (leave empty to use the default branch or the branch that triggered the workflow)'
         required: false
         type: string
+      artifact_name_prefix:
+        description: 'Optional prefix for uploaded artifact names'
+        required: false
+        default: ''
+        type: string
       skip_build_and_test_release_tag:
         description: 'Release tag to download prebuilt Linux artifacts instead of building (leave empty to build)'
         required: false
         default: ''
         type: string
+      run_tests:
+        description: 'Run the Linux smoke tests after the build'
+        required: false
+        default: true
+        type: boolean
   workflow_call:
+    inputs:
+      commitHash:
+        required: false
+        type: string
+        default: ''
+      artifact_name_prefix:
+        required: false
+        type: string
+        default: ''
+      skip_build_and_test_release_tag:
+        required: false
+        type: string
+        default: ''
+      run_tests:
+        required: false
+        type: boolean
+        default: true
 
 
 jobs:
@@ -33,22 +60,22 @@ jobs:
 
       # 2) if a SHA was provided, fetch it and switch to it
       - name: Fetch and checkout custom commit
-        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.commitHash != '' }}
+        if: ${{ inputs.commitHash != '' }}
         run: |
           # this will succeed as long as the commit is reachable from ANY branch on the remote
-          git fetch origin ${{ github.event.inputs.commitHash }}
-          git checkout ${{ github.event.inputs.commitHash }}
+          git fetch origin ${{ inputs.commitHash }}
+          git checkout ${{ inputs.commitHash }}
           
       # Use the build path for all non-dispatch events, or dispatch events that did not request a prebuilt release download.
       # When skip_build_and_test_release_tag is non-empty on workflow_dispatch, the release-download path is used instead.
       - name: Set up Python environment
-        if: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.skip_build_and_test_release_tag == '' }}
+        if: ${{ github.event_name != 'workflow_dispatch' || inputs.skip_build_and_test_release_tag == '' }}
         uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 
       - name: Setup xvfb (Linux)
-        if: ${{ (github.event_name != 'workflow_dispatch' || github.event.inputs.skip_build_and_test_release_tag == '') && runner.os == 'Linux' }}
+        if: ${{ (github.event_name != 'workflow_dispatch' || inputs.skip_build_and_test_release_tag == '') && runner.os == 'Linux' }}
         run: |
           sudo apt-get update
           sudo apt-get install -y xvfb \
@@ -73,19 +100,19 @@ jobs:
                                 libxkbcommon-x11-dev 
 
       - name: Install Python dependencies
-        if: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.skip_build_and_test_release_tag == '' }}
+        if: ${{ github.event_name != 'workflow_dispatch' || inputs.skip_build_and_test_release_tag == '' }}
         run: |
           python -m pip install --upgrade pip
           pip install poetry
           poetry install
 
       - name: Run build script
-        if: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.skip_build_and_test_release_tag == '' }}
+        if: ${{ github.event_name != 'workflow_dispatch' || inputs.skip_build_and_test_release_tag == '' }}
         run: poetry run python tools/build.py --targets appimage deb --commit None
 
 
       - name: Check for AppImage file
-        if: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.skip_build_and_test_release_tag == '' }}
+        if: ${{ github.event_name != 'workflow_dispatch' || inputs.skip_build_and_test_release_tag == '' }}
         run: |
           if [ -z "$(find dist -type f -name '*.AppImage.*')" ]; then
             echo "AppImage file is missing"
@@ -93,7 +120,7 @@ jobs:
           fi
 
       - name: Check for deb file
-        if: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.skip_build_and_test_release_tag == '' }}
+        if: ${{ github.event_name != 'workflow_dispatch' || inputs.skip_build_and_test_release_tag == '' }}
         run: |
           if [ -z "$(find dist -type f -name '*.deb')" ]; then
             echo "deb file is missing"
@@ -103,14 +130,15 @@ jobs:
 
 
       - name: Upload Linux artifacts
-        if: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.skip_build_and_test_release_tag == '' }}
+        if: ${{ github.event_name != 'workflow_dispatch' || inputs.skip_build_and_test_release_tag == '' }}
         uses: actions/upload-artifact@v7
         with:
-          name: linux-artifacts
+          name: ${{ inputs.artifact_name_prefix }}linux-artifacts
           path: dist/
           if-no-files-found: error
 
   test:
+    if: ${{ inputs.run_tests }}
     needs: build
     runs-on: ubuntu-22.04
     strategy:
@@ -122,14 +150,14 @@ jobs:
       XDG_RUNTIME_DIR: /tmp/runtime-bitcoin-safe
     steps:
       - name: Download build artifacts
-        if: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.skip_build_and_test_release_tag == '' }}
+        if: ${{ github.event_name != 'workflow_dispatch' || inputs.skip_build_and_test_release_tag == '' }}
         uses: actions/download-artifact@v7
         with:
-          name: linux-artifacts
+          name: ${{ inputs.artifact_name_prefix }}linux-artifacts
           path: artifacts
 
       - name: Unpack AppImage archive
-        if: ${{ matrix.package == 'appimage' && (github.event_name != 'workflow_dispatch' || github.event.inputs.skip_build_and_test_release_tag == '') }}
+        if: ${{ matrix.package == 'appimage' && (github.event_name != 'workflow_dispatch' || inputs.skip_build_and_test_release_tag == '') }}
         run: |
           set -euo pipefail
           shopt -s globstar nullglob
@@ -149,13 +177,13 @@ jobs:
           fi
 
       - name: Download release artifacts
-        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.skip_build_and_test_release_tag != '' }}
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.skip_build_and_test_release_tag != '' }}
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           mkdir -p artifacts
-          gh release download "${{ github.event.inputs.skip_build_and_test_release_tag }}" \
+          gh release download "${{ inputs.skip_build_and_test_release_tag }}" \
             --dir artifacts \
             --repo "${{ github.repository }}"
           shopt -s nullglob
@@ -167,7 +195,7 @@ jobs:
           done
 
       - name: Verify downloaded Linux artifacts
-        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.skip_build_and_test_release_tag != '' }}
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.skip_build_and_test_release_tag != '' }}
         run: |
           set -euo pipefail
           if ! find artifacts -type f -name '*.AppImage' -print -quit | grep -q .; then

--- a/.github/workflows/build-flatpak-and-test.yml
+++ b/.github/workflows/build-flatpak-and-test.yml
@@ -9,12 +9,30 @@ on:
         description: "Enter the commit hash to build (leave empty to use the default branch or the branch that triggered the workflow)"
         required: false
         type: string
+      artifact_name_prefix:
+        description: "Optional prefix for uploaded artifact names"
+        required: false
+        default: ""
+        type: string
+      run_tests:
+        description: "Run the Flatpak smoke test after the build"
+        required: false
+        default: true
+        type: boolean
   workflow_call:
     inputs:
       commitHash:
         required: false
         type: string
         default: ""
+      artifact_name_prefix:
+        required: false
+        type: string
+        default: ""
+      run_tests:
+        required: false
+        type: boolean
+        default: true
 
 jobs:
   build:
@@ -79,13 +97,14 @@ jobs:
       - name: Upload Flatpak artifact
         uses: actions/upload-artifact@v4
         with:
-          name: flatpak-artifacts
+          name: ${{ inputs.artifact_name_prefix }}flatpak-artifacts
           path: |
             dist/*.flatpak
             tools/build-linux/flatpak/build/repro-debug/**
           if-no-files-found: error
 
   test:
+    if: ${{ inputs.run_tests }}
     needs: build
     runs-on: ubuntu-24.04
     timeout-minutes: 120
@@ -108,7 +127,7 @@ jobs:
       - name: Download Flatpak artifact
         uses: actions/download-artifact@v4
         with:
-          name: flatpak-artifacts
+          name: ${{ inputs.artifact_name_prefix }}flatpak-artifacts
           path: artifacts
 
       - name: Install Linux test dependencies

--- a/.github/workflows/build-windows-and-test.yml
+++ b/.github/workflows/build-windows-and-test.yml
@@ -10,6 +10,11 @@ on:
         description: 'Enter the commit hash to build (empty = the main branch or the branch that triggered the workflow)'
         required: false
         type: string
+      artifact_name_prefix:
+        description: 'Optional prefix for uploaded artifact names'
+        required: false
+        default: ''
+        type: string
       signing-policy-slug:
         description: 'signing-policy-slug  ("" for no signing, "test-signing", "release-signing" for valid signing)'
         required: false
@@ -24,11 +29,20 @@ on:
         required: false
         default: ''
         type: string
+      run_tests:
+        description: 'Run the Windows smoke test after the build'
+        required: false
+        default: true
+        type: boolean
   workflow_call:
     inputs:
       commitHash:
         required: false
         type: string
+      artifact_name_prefix:
+        required: false
+        type: string
+        default: ''
       signing-policy-slug:
         required: false
         type: string
@@ -37,6 +51,10 @@ on:
         required: false
         type: string
         default: ''
+      run_tests:
+        required: false
+        type: boolean
+        default: true
 
 jobs:
   build:
@@ -50,22 +68,22 @@ jobs:
 
       # 2) if a SHA was provided, fetch it and switch to it
       - name: Fetch and checkout custom commit
-        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.commitHash != '' }}
+        if: ${{ inputs.commitHash != '' }}
         run: |
           # this will succeed as long as the commit is reachable from ANY branch on the remote
-          git fetch origin ${{ github.event.inputs.commitHash }}
-          git checkout ${{ github.event.inputs.commitHash }}
+          git fetch origin ${{ inputs.commitHash }}
+          git checkout ${{ inputs.commitHash }}
 
       # Use the build path for all non-dispatch events, or dispatch events that did not request a prebuilt release download.
       # When skip_build_and_test_release_tag is non-empty on workflow_dispatch, the release-download path is used instead.
       - name: Set up Python environment
-        if: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.skip_build_and_test_release_tag == '' }}
+        if: ${{ github.event_name != 'workflow_dispatch' || inputs.skip_build_and_test_release_tag == '' }}
         uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 
       - name: Setup xvfb (Linux)
-        if: ${{ (github.event_name != 'workflow_dispatch' || github.event.inputs.skip_build_and_test_release_tag == '') && runner.os == 'Linux' }}
+        if: ${{ (github.event_name != 'workflow_dispatch' || inputs.skip_build_and_test_release_tag == '') && runner.os == 'Linux' }}
         run: |
           sudo apt-get update
           sudo apt-get install -y xvfb \
@@ -91,19 +109,19 @@ jobs:
                                 osslsigncode
 
       - name: Install Python dependencies
-        if: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.skip_build_and_test_release_tag == '' }}
+        if: ${{ github.event_name != 'workflow_dispatch' || inputs.skip_build_and_test_release_tag == '' }}
         run: |
           python -m pip install --upgrade pip
           pip install poetry
           poetry install
 
       - name: Run build script
-        if: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.skip_build_and_test_release_tag == '' }}
+        if: ${{ github.event_name != 'workflow_dispatch' || inputs.skip_build_and_test_release_tag == '' }}
         run: poetry run python tools/build.py --targets windows --commit None
 
 
       - name: Check for portable EXE file
-        if: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.skip_build_and_test_release_tag == '' }}
+        if: ${{ github.event_name != 'workflow_dispatch' || inputs.skip_build_and_test_release_tag == '' }}
         run: |
           if [ -z "$(find dist -type f -name '*portable.exe')" ]; then
             echo "Portable EXE file is missing"
@@ -111,7 +129,7 @@ jobs:
           fi
 
       - name: Check for setup EXE file
-        if: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.skip_build_and_test_release_tag == '' }}
+        if: ${{ github.event_name != 'workflow_dispatch' || inputs.skip_build_and_test_release_tag == '' }}
         run: |
           if [ -z "$(find dist -type f -name '*setup.exe')" ]; then
             echo "Setup EXE file is missing"
@@ -119,68 +137,69 @@ jobs:
           fi
 
       - name: Upload EXE Files from dist/
-        if: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.skip_build_and_test_release_tag == '' }}
+        if: ${{ github.event_name != 'workflow_dispatch' || inputs.skip_build_and_test_release_tag == '' }}
         id: upload-unsigned-artifact
         uses: actions/upload-artifact@v7
         with:
-          name: win-artifacts
+          name: ${{ inputs.artifact_name_prefix }}win-artifacts
           path: dist/*  # zip everything in the folder
 
-      - name: 'signing with ${{ github.event.inputs.signing-policy-slug }}'
+      - name: 'signing with ${{ inputs.signing-policy-slug }}'
         id: signpath-io
-        if: ${{ github.event.inputs.skip_build_and_test_release_tag == '' && github.event.inputs.signing-policy-slug != '' }}
+        if: ${{ inputs.skip_build_and_test_release_tag == '' && inputs.signing-policy-slug != '' }}
         uses: signpath/github-action-submit-signing-request@v1.1
         with:
           api-token: '${{ secrets.SIGNPATH_API_TOKEN }}'
           organization-id: '0981059c-bbd4-461c-abcf-b99bd074a723'
           project-slug: 'bitcoin-safe'
-          signing-policy-slug: '${{ github.event.inputs.signing-policy-slug }}'
+          signing-policy-slug: '${{ inputs.signing-policy-slug }}'
           github-artifact-id: '${{ steps.upload-unsigned-artifact.outputs.artifact-id }}'
           artifact-configuration-slug: 'Win'
           wait-for-completion: true
           output-artifact-directory: 'signpath-signed'
 
       - name: Upload Signed EXE Files from signpath-signed/
-        if: ${{ github.event.inputs.skip_build_and_test_release_tag == '' && github.event.inputs.signing-policy-slug != '' }}
+        if: ${{ inputs.skip_build_and_test_release_tag == '' && inputs.signing-policy-slug != '' }}
         id: upload-signed-artifact
         uses: actions/upload-artifact@v7
         with:
-          name: win-artifacts-signpath-signed
+          name: ${{ inputs.artifact_name_prefix }}win-artifacts-signpath-signed
           path: signpath-signed/*  # zip everything in the folder
 
 
       - name: Compare signed and unsigned files
-        if: ${{ github.event.inputs.skip_build_and_test_release_tag == '' && github.event.inputs.signing-policy-slug != '' }}
+        if: ${{ inputs.skip_build_and_test_release_tag == '' && inputs.signing-policy-slug != '' }}
         run: |
           tools/build-wine/verify_signed_executables.sh dist signpath-signed portable setup
 
   test-portable:
+    if: ${{ inputs.run_tests }}
     needs: build
     runs-on: windows-latest
     steps:
       - name: Download signed portable artifact
-        if: ${{ github.event.inputs.skip_build_and_test_release_tag == '' && github.event.inputs.signing-policy-slug != '' }}
+        if: ${{ inputs.skip_build_and_test_release_tag == '' && inputs.signing-policy-slug != '' }}
         uses: actions/download-artifact@v7
         with:
-          name: win-artifacts-signpath-signed
+          name: ${{ inputs.artifact_name_prefix }}win-artifacts-signpath-signed
           path: artifacts
 
       - name: Download unsigned portable artifact
-        if: ${{ github.event.inputs.skip_build_and_test_release_tag == '' && github.event.inputs.signing-policy-slug == '' }}
+        if: ${{ inputs.skip_build_and_test_release_tag == '' && inputs.signing-policy-slug == '' }}
         uses: actions/download-artifact@v7
         with:
-          name: win-artifacts
+          name: ${{ inputs.artifact_name_prefix }}win-artifacts
           path: artifacts
 
       - name: Download release artifacts
-        if: ${{ github.event.inputs.skip_build_and_test_release_tag != '' }}
+        if: ${{ inputs.skip_build_and_test_release_tag != '' }}
         env:
           GH_TOKEN: ${{ github.token }}
         shell: bash
         run: |
           set -euo pipefail
           mkdir -p artifacts
-          gh release download "${{ github.event.inputs.skip_build_and_test_release_tag }}" \
+          gh release download "${{ inputs.skip_build_and_test_release_tag }}" \
             --dir artifacts \
             --repo "${{ github.repository }}"
           shopt -s nullglob
@@ -192,7 +211,7 @@ jobs:
           done
 
       - name: Verify downloaded Windows artifacts
-        if: ${{ github.event.inputs.skip_build_and_test_release_tag != '' }}
+        if: ${{ inputs.skip_build_and_test_release_tag != '' }}
         shell: bash
         run: |
           set -euo pipefail

--- a/.github/workflows/check-build-reproducibility.yml
+++ b/.github/workflows/check-build-reproducibility.yml
@@ -1,0 +1,269 @@
+name: Check Build Reproducibility
+permissions:
+  contents: read
+
+on:
+  workflow_dispatch:
+    inputs:
+      commitHash:
+        description: "Enter the commit hash to build twice (leave empty to use the current branch HEAD)"
+        required: false
+        type: string
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - labeled
+
+jobs:
+  linux-run-1:
+    if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'Reproducibility-Relevant')) }}
+    uses: ./.github/workflows/build-appimage-and-test.yml
+    with:
+      commitHash: ${{ github.event_name == 'workflow_dispatch' && inputs.commitHash || github.event.pull_request.head.sha || '' }}
+      artifact_name_prefix: repro-linux-run-1-
+      run_tests: false
+    secrets: inherit
+
+  linux-run-2:
+    if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'Reproducibility-Relevant')) }}
+    uses: ./.github/workflows/build-appimage-and-test.yml
+    with:
+      commitHash: ${{ github.event_name == 'workflow_dispatch' && inputs.commitHash || github.event.pull_request.head.sha || '' }}
+      artifact_name_prefix: repro-linux-run-2-
+      run_tests: false
+    secrets: inherit
+
+  compare-linux:
+    if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'Reproducibility-Relevant')) }}
+    needs:
+      - linux-run-1
+      - linux-run-2
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Download first Linux artifact set
+        uses: actions/download-artifact@v7
+        with:
+          name: repro-linux-run-1-linux-artifacts
+          path: artifacts/linux-run-1
+
+      - name: Download second Linux artifact set
+        uses: actions/download-artifact@v7
+        with:
+          name: repro-linux-run-2-linux-artifacts
+          path: artifacts/linux-run-2
+
+      - name: Compare Linux AppImage tarball checksums
+        id: compare_linux_appimage_tarballs
+        continue-on-error: true
+        run: |
+          python tools/compare_artifact_sets.py \
+            --first-dir artifacts/linux-run-1 \
+            --second-dir artifacts/linux-run-2 \
+            --pattern '*.AppImage.tar.gz' \
+            --label 'Linux AppImage tarballs'
+
+      - name: Compare Linux deb checksums
+        id: compare_linux_debs
+        continue-on-error: true
+        run: |
+          python tools/compare_artifact_sets.py \
+            --first-dir artifacts/linux-run-1 \
+            --second-dir artifacts/linux-run-2 \
+            --pattern '*.deb' \
+            --label 'Linux debs'
+
+      - name: Extract AppImage tarballs
+        run: |
+          set -euo pipefail
+          for directory in artifacts/linux-run-1 artifacts/linux-run-2; do
+            find "$directory" -type f -name '*.AppImage.tar.gz' -print0 | while IFS= read -r -d '' archive; do
+              tar -xzf "$archive" -C "$(dirname "$archive")"
+            done
+          done
+
+      - name: Compare extracted AppImage checksums
+        id: compare_linux_appimages
+        continue-on-error: true
+        run: |
+          python tools/compare_artifact_sets.py \
+            --first-dir artifacts/linux-run-1 \
+            --second-dir artifacts/linux-run-2 \
+            --pattern '*.AppImage' \
+            --label 'Linux AppImage payloads'
+
+      - name: Install AppImage diff dependencies
+        if: ${{ steps.compare_linux_appimages.outcome == 'failure' }}
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y squashfs-tools
+
+      - name: Run AppImage diff report
+        if: ${{ steps.compare_linux_appimages.outcome == 'failure' }}
+        run: |
+          set -euo pipefail
+          APPIMAGE_A=$(find artifacts/linux-run-1 -type f -name '*.AppImage' | head -n 1)
+          APPIMAGE_B=$(find artifacts/linux-run-2 -type f -name '*.AppImage' | head -n 1)
+          bash tools/build-linux/appimage/appimage-diff-report.sh \
+            --work artifacts/appimage-diff-report \
+            "$APPIMAGE_A" \
+            "$APPIMAGE_B"
+
+      - name: Upload AppImage diff report
+        if: ${{ steps.compare_linux_appimages.outcome == 'failure' }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: linux-appimage-diff-report
+          path: artifacts/appimage-diff-report
+          if-no-files-found: error
+
+      - name: Fail on Linux reproducibility mismatches
+        if: ${{ steps.compare_linux_appimage_tarballs.outcome == 'failure' || steps.compare_linux_debs.outcome == 'failure' || steps.compare_linux_appimages.outcome == 'failure' }}
+        run: |
+          echo "Linux reproducibility mismatch detected."
+          exit 1
+
+  flatpak-run-1:
+    if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'Reproducibility-Relevant')) }}
+    uses: ./.github/workflows/build-flatpak-and-test.yml
+    with:
+      commitHash: ${{ github.event_name == 'workflow_dispatch' && inputs.commitHash || github.event.pull_request.head.sha || '' }}
+      artifact_name_prefix: repro-flatpak-run-1-
+      run_tests: false
+    secrets: inherit
+
+  flatpak-run-2:
+    if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'Reproducibility-Relevant')) }}
+    uses: ./.github/workflows/build-flatpak-and-test.yml
+    with:
+      commitHash: ${{ github.event_name == 'workflow_dispatch' && inputs.commitHash || github.event.pull_request.head.sha || '' }}
+      artifact_name_prefix: repro-flatpak-run-2-
+      run_tests: false
+    secrets: inherit
+
+  compare-flatpak:
+    if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'Reproducibility-Relevant')) }}
+    needs:
+      - flatpak-run-1
+      - flatpak-run-2
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Download first Flatpak artifact set
+        uses: actions/download-artifact@v4
+        with:
+          name: repro-flatpak-run-1-flatpak-artifacts
+          path: artifacts/flatpak-run-1
+
+      - name: Download second Flatpak artifact set
+        uses: actions/download-artifact@v4
+        with:
+          name: repro-flatpak-run-2-flatpak-artifacts
+          path: artifacts/flatpak-run-2
+
+      - name: Compare Flatpak artifact checksums
+        run: |
+          python tools/compare_artifact_sets.py \
+            --first-dir artifacts/flatpak-run-1 \
+            --second-dir artifacts/flatpak-run-2 \
+            --pattern '*.flatpak' \
+            --label Flatpak
+
+  windows-run-1:
+    if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'Reproducibility-Relevant')) }}
+    uses: ./.github/workflows/build-windows-and-test.yml
+    with:
+      commitHash: ${{ github.event_name == 'workflow_dispatch' && inputs.commitHash || github.event.pull_request.head.sha || '' }}
+      artifact_name_prefix: repro-windows-run-1-
+      run_tests: false
+    secrets: inherit
+
+  windows-run-2:
+    if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'Reproducibility-Relevant')) }}
+    uses: ./.github/workflows/build-windows-and-test.yml
+    with:
+      commitHash: ${{ github.event_name == 'workflow_dispatch' && inputs.commitHash || github.event.pull_request.head.sha || '' }}
+      artifact_name_prefix: repro-windows-run-2-
+      run_tests: false
+    secrets: inherit
+
+  compare-windows:
+    if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'Reproducibility-Relevant')) }}
+    needs:
+      - windows-run-1
+      - windows-run-2
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Download first Windows artifact set
+        uses: actions/download-artifact@v7
+        with:
+          name: repro-windows-run-1-win-artifacts
+          path: artifacts/windows-run-1
+
+      - name: Download second Windows artifact set
+        uses: actions/download-artifact@v7
+        with:
+          name: repro-windows-run-2-win-artifacts
+          path: artifacts/windows-run-2
+
+      - name: Compare Windows portable checksums
+        id: compare_windows_portable
+        continue-on-error: true
+        run: |
+          python tools/compare_artifact_sets.py \
+            --first-dir artifacts/windows-run-1 \
+            --second-dir artifacts/windows-run-2 \
+            --pattern '*portable.exe' \
+            --label 'Windows portable'
+
+      - name: Compare Windows setup checksums
+        id: compare_windows_setup
+        continue-on-error: true
+        run: |
+          python tools/compare_artifact_sets.py \
+            --first-dir artifacts/windows-run-1 \
+            --second-dir artifacts/windows-run-2 \
+            --pattern '*setup.exe' \
+            --label 'Windows setup'
+
+      - name: Install Windows diff dependencies
+        if: ${{ steps.compare_windows_setup.outcome == 'failure' }}
+        run: |
+          python -m pip install --upgrade pip
+          pip install pefile
+
+      - name: Run Windows setup diff report
+        if: ${{ steps.compare_windows_setup.outcome == 'failure' }}
+        run: |
+          python tools/build-wine/compare_setup_builds.py \
+            --local artifacts/windows-run-1 \
+            --cloud artifacts/windows-run-2 \
+            --local-json artifacts/windows-run-1/setup-compare-local.json \
+            --cloud-json artifacts/windows-run-2/setup-compare-cloud.json \
+            > artifacts/windows-setup-diff-report.txt
+
+      - name: Upload Windows setup diff report
+        if: ${{ steps.compare_windows_setup.outcome == 'failure' }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: windows-setup-diff-report
+          path: |
+            artifacts/windows-setup-diff-report.txt
+            artifacts/windows-run-1/setup-compare-local.json
+            artifacts/windows-run-2/setup-compare-cloud.json
+          if-no-files-found: error
+
+      - name: Fail on Windows reproducibility mismatches
+        if: ${{ steps.compare_windows_portable.outcome == 'failure' || steps.compare_windows_setup.outcome == 'failure' }}
+        run: |
+          echo "Windows reproducibility mismatch detected."
+          exit 1

--- a/tools/appimage_to_deb_converter.py
+++ b/tools/appimage_to_deb_converter.py
@@ -27,7 +27,6 @@
 # SOFTWARE.
 #
 import os
-import shutil
 import subprocess
 import tempfile
 from collections.abc import Iterable
@@ -136,9 +135,9 @@ class Appimage2debConverter:
         debian_dir = package_root / "DEBIAN"
         target_dir = package_root / "opt" / self.package_name
         debian_dir.mkdir(parents=True, exist_ok=True)
-        target_dir.mkdir(parents=True, exist_ok=True)
-        # Copy the extracted AppImage contents into /opt/<package_name>.
-        shutil.copytree(str(extracted_folder), str(target_dir), dirs_exist_ok=True, symlinks=True)
+        target_dir.parent.mkdir(parents=True, exist_ok=True)
+        # Keep staging on the same filesystem so we do not duplicate the full AppImage payload in /tmp.
+        extracted_folder.rename(target_dir)
 
     def _create_control_file(self, debian_dir: Path) -> None:
         # Build the control file content line by line.

--- a/tools/build.py
+++ b/tools/build.py
@@ -30,6 +30,7 @@
 from __future__ import annotations
 
 import argparse
+import gzip
 import hashlib
 import logging
 import os
@@ -476,11 +477,52 @@ class Builder:
 
             tarball_path = appimage_path.with_suffix(appimage_path.suffix + ".tar.gz")
             logger.info(f"Creating tarball {tarball_path}")
-            with tarfile.open(tarball_path, "w:gz") as tar:
-                tar.add(appimage_path, arcname=appimage_path.name)
+            source_date_epoch = self.resolve_source_date_epoch()
+            with tarball_path.open("wb") as file_handle:
+                with gzip.GzipFile(
+                    filename="",
+                    mode="wb",
+                    fileobj=file_handle,
+                    mtime=source_date_epoch,
+                ) as gzip_file_handle:
+                    with tarfile.open(fileobj=gzip_file_handle, mode="w") as tar:
+                        tar_info = tar.gettarinfo(str(appimage_path), arcname=appimage_path.name)
+                        tar_info.mtime = source_date_epoch
+                        tar_info.uid = 0
+                        tar_info.gid = 0
+                        tar_info.uname = ""
+                        tar_info.gname = ""
+                        with appimage_path.open("rb") as appimage_file_handle:
+                            tar.addfile(tar_info, appimage_file_handle)
 
             logger.info(f"Removing original AppImage {appimage_path}")
             appimage_path.unlink()
+
+    @staticmethod
+    def resolve_source_date_epoch() -> int:
+        """Resolve a deterministic timestamp for reproducible archive metadata."""
+        epoch = os.environ.get("SOURCE_DATE_EPOCH")
+        if epoch:
+            try:
+                return int(epoch)
+            except ValueError:
+                logger.warning("Invalid SOURCE_DATE_EPOCH value %r. Falling back to git commit time.", epoch)
+
+        try:
+            result = subprocess.run(
+                ["git", "log", "-1", "--format=%ct"],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                check=True,
+                text=True,
+            )
+            git_epoch = result.stdout.strip()
+            if git_epoch:
+                return int(git_epoch)
+        except (ValueError, subprocess.CalledProcessError, FileNotFoundError):
+            logger.warning("Failed to resolve git commit time. Falling back to default SOURCE_DATE_EPOCH.")
+
+        return 1530212462
 
     def sign(self):
         """Sign."""

--- a/tools/compare_artifact_sets.py
+++ b/tools/compare_artifact_sets.py
@@ -1,0 +1,123 @@
+#
+# Bitcoin Safe
+# Copyright (C) 2026 Andreas Griffin
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of version 3 of the GNU General Public License as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see https://www.gnu.org/licenses/gpl-3.0.html
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+# BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+# ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import hashlib
+from pathlib import Path
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Compare SHA-256 checksums across two artifact directories.")
+    parser.add_argument(
+        "--first-dir", type=Path, required=True, help="Directory containing the first artifact set."
+    )
+    parser.add_argument(
+        "--second-dir", type=Path, required=True, help="Directory containing the second artifact set."
+    )
+    parser.add_argument(
+        "--pattern",
+        action="append",
+        required=True,
+        help="Filename glob to include in the comparison. Repeat to include multiple patterns.",
+    )
+    parser.add_argument("--label", default="artifact set", help="Human-readable label used in log output.")
+    return parser.parse_args()
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as file_handle:
+        while chunk := file_handle.read(1024 * 1024):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def matches_patterns(path: Path, patterns: list[str]) -> bool:
+    return any(fnmatch.fnmatch(path.name, pattern) for pattern in patterns)
+
+
+def collect_artifacts(root_dir: Path, patterns: list[str]) -> dict[str, Path]:
+    if not root_dir.is_dir():
+        raise ValueError(f"Artifact directory does not exist: {root_dir}")
+
+    artifacts: dict[str, Path] = {}
+    for path in sorted(root_dir.rglob("*")):
+        if not path.is_file() or not matches_patterns(path, patterns):
+            continue
+        existing_path = artifacts.get(path.name)
+        if existing_path is not None:
+            raise ValueError(
+                f"Found duplicate artifact basename {path.name!r} under {root_dir}: {existing_path} and {path}"
+            )
+        artifacts[path.name] = path
+
+    if not artifacts:
+        joined_patterns = ", ".join(patterns)
+        raise ValueError(f"No artifacts matching {joined_patterns} found under {root_dir}")
+
+    return artifacts
+
+
+def compare_artifacts(first_dir: Path, second_dir: Path, patterns: list[str], label: str) -> int:
+    first_artifacts = collect_artifacts(first_dir, patterns)
+    second_artifacts = collect_artifacts(second_dir, patterns)
+
+    first_names = set(first_artifacts)
+    second_names = set(second_artifacts)
+    if first_names != second_names:
+        missing_from_first = sorted(second_names - first_names)
+        missing_from_second = sorted(first_names - second_names)
+        if missing_from_first:
+            print(f"{label}: missing from first build: {', '.join(missing_from_first)}")
+        if missing_from_second:
+            print(f"{label}: missing from second build: {', '.join(missing_from_second)}")
+        return 1
+
+    has_mismatch = False
+    for artifact_name in sorted(first_names):
+        first_hash = sha256_file(first_artifacts[artifact_name])
+        second_hash = sha256_file(second_artifacts[artifact_name])
+        status = "MATCH" if first_hash == second_hash else "MISMATCH"
+        print(f"{label}: {artifact_name}: {status}\n  first : {first_hash}\n  second: {second_hash}")
+        if first_hash != second_hash:
+            has_mismatch = True
+
+    return 1 if has_mismatch else 0
+
+
+def main() -> int:
+    args = parse_args()
+    return compare_artifacts(args.first_dir, args.second_dir, args.pattern, args.label)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
smoke test for reproducibility

- appimage
- deb
- flatpak
- win portable
- win setup

## Required

- `pre-commit install` before any commit. If pre-commit wasn't run for all commits, you can squash all commits   `git reset --soft $(git merge-base main HEAD) && git commit -m "squash"` and ensure the squashed commit is properly formatted
- All commits must be signed. If some are not, you can squash all commits   `git reset --soft $(git merge-base main HEAD) && git commit -m "squash"` and ensure the squashed commit is signed
- [ ] UI/Design/Menu changes **were** tested on _macOS_, because _macOS_ creates endless problems.  Optionally attach a screenshot.
 
## Optional

- [ ] Update all translations
- [ ] Appropriate pytests were added
- [ ] Documentation is updated
- [ ] If this PR affects builds or install artifacts, set the `Build-Relevant` label to trigger build workflows
