### PR TITLE
Fix UI spacing and improve component hierarchy

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,4 +11,7 @@
 - [ ] Documentation is updated
 - [ ] If this PR affects builds or install artifacts, set the `Build-Relevant` label to trigger build workflows
 - [ ] If this PR affects reproducible build outputs, set the `Reproducibility-Relevant` label to trigger the checksum comparison workflow
-- [ ] Instruct AI `create a concise summary (bullet points, no stats) for this pr and make a good title`
+- [ ] Instruct AI 
+```
+create a concise summary (bullet points, no stats) for this pr and make a good title
+```

--- a/bitcoin_safe/gui/qt/descriptor_ui.py
+++ b/bitcoin_safe/gui/qt/descriptor_ui.py
@@ -51,7 +51,6 @@ from PyQt6.QtWidgets import (
     QPushButton,
     QSizePolicy,
     QSpinBox,
-    QStyle,
     QVBoxLayout,
     QWidget,
 )
@@ -61,7 +60,7 @@ from bitcoin_safe.gui.qt.descriptor_edit import DescriptorEdit
 from bitcoin_safe.gui.qt.icon_label import IconLabel
 from bitcoin_safe.gui.qt.keystore_uis import KeyStoreUIs
 from bitcoin_safe.gui.qt.register_multisig import RegisterMultisigInteractionWidget
-from bitcoin_safe.gui.qt.util import Message, MessageType, set_margins
+from bitcoin_safe.gui.qt.util import Message, MessageType, set_margins, svg_tools
 from bitcoin_safe.hardware_signers import HardwareSigner
 from bitcoin_safe.signals import WalletFunctions
 from bitcoin_safe.wallet import ProtoWallet, Wallet
@@ -625,15 +624,13 @@ class DescriptorUI(QWidget):
     def create_button_bar(self) -> QDialogButtonBox:
         """Create button bar."""
         self.button_box = QDialogButtonBox(self)
-        style = self.button_box.style() or QStyle()
         discard_button = QPushButton(self.tr("Discard"), self.button_box)
-        discard_button.setIcon(style.standardIcon(QStyle.StandardPixmap.SP_DialogDiscardButton))
         discard_button.clicked.connect(self.signal_qtwallet_cancel_setting_changes.emit)
         discard_button.clicked.connect(self.signal_qtwallet_cancel_wallet_creation.emit)
         self.button_box.addButton(discard_button, QDialogButtonBox.ButtonRole.ResetRole)
 
         apply_button = QPushButton(self.tr("Apply"), self.button_box)
-        apply_button.setIcon(style.standardIcon(QStyle.StandardPixmap.SP_DialogApplyButton))
+        apply_button.setIcon(svg_tools.get_QIcon("checkmark.svg"))
         apply_button.clicked.connect(self.signal_qtwallet_apply_setting_changes.emit)
         self.button_box.addButton(apply_button, QDialogButtonBox.ButtonRole.AcceptRole)
 

--- a/bitcoin_safe/gui/qt/ui_tx/recipients.py
+++ b/bitcoin_safe/gui/qt/ui_tx/recipients.py
@@ -123,19 +123,22 @@ class RecipientWidget(QWidget):
             dismiss_label_on_focus_loss=False,
         )
 
-        self.amount_layout = QHBoxLayout()
+        self.amount_container = QWidget(self)
+        self.amount_layout = QHBoxLayout(self.amount_container)
+        set_no_margins(self.amount_layout)
         language_switch = cast(SignalProtocol[[]], self.wallet_functions.signals.language_switch)
         self.amount_spin_box = BTCSpinBox(
             network=network,
             signal_language_switch=language_switch,
             btc_symbol=self.wallet_functions.signals.get_btc_symbol() or BitcoinSymbol.ISO.value,
+            parent=self,
         )
-        amount_analyzer = AmountAnalyzer()
+        amount_analyzer = AmountAnalyzer(self)
         amount_analyzer.min_amount = 0
         amount_analyzer.max_amount = int(21e6 * 1e8)
         self.amount_spin_box.setAnalyzer(amount_analyzer)
         self.label_unit = QLabel(self.fx.config.bitcoin_symbol.value if self.fx else BitcoinSymbol.ISO.value)
-        self.send_max_checkbox = QCheckBox()
+        self.send_max_checkbox = QCheckBox(self)
         self.signal_tracker.connect(
             cast(SignalProtocol[[]], self.send_max_checkbox.clicked), self.on_send_max_button_click
         )
@@ -176,7 +179,7 @@ class RecipientWidget(QWidget):
         self.form_layout.addRow(self.address_label, self.address_edit)
         self.form_layout.addRow(self.label_txlabel, self.label_line_edit)
         self.form_layout.addRow(self.fiat_label, self.fiat_layout)
-        self.form_layout.addRow(self.amount_label, self.amount_layout)
+        self.form_layout.addRow(self.amount_label, self.amount_container)
 
         self.set_allow_edit(allow_edit)
         self.label_line_edit.set_label_readonly(not allow_label_edit)

--- a/bitcoin_safe/gui/qt/util.py
+++ b/bitcoin_safe/gui/qt/util.py
@@ -967,7 +967,7 @@ def clipboard_contains_address(network: bdk.Network) -> bool:
     return ConverterAddress.is_bitcoin_address(clipboard.text(), network)
 
 
-def do_copy(text: str, *, title: str | None = None) -> None:
+def do_copy(text: str, title: str | None = None, parent: QWidget | None = None) -> None:
     """Do copy."""
     clipboard = QApplication.clipboard()
     if not clipboard:
@@ -979,16 +979,17 @@ def do_copy(text: str, *, title: str | None = None) -> None:
         if title is None
         else translate("d", "{} copied to Clipboard").format(title)
     )
-    show_tooltip_after_delay(message)
+    show_tooltip_after_delay(message=message, parent=parent)
 
 
-def show_tooltip_after_delay(message):
+def show_tooltip_after_delay(message: str, parent: QWidget | None = None) -> None:
     """Show tooltip after delay."""
-    timer = QTimer()
     if not ENABLE_TIMERS:
         return
     # tooltip cannot be displayed immediately when called from a menu; wait 200ms
-    timer.singleShot(200, partial(QToolTip.showText, QCursor.pos(), message))
+    QTimer.singleShot(
+        200, partial(QToolTip.showText, QCursor.pos(), message, parent or QApplication.activeWindow())
+    )
 
 
 def qicon_to_pil(qicon: QIcon, size=200) -> PilImage.Image:

--- a/bitcoin_safe/gui/qt/warning_bars.py
+++ b/bitcoin_safe/gui/qt/warning_bars.py
@@ -190,7 +190,7 @@ class TooSmallGapLimitWarningBar(NotificationBar):
             text="",
             optional_button_text="",
             callback_optional_button=self.click_recreate,
-            has_close_button=False,
+            has_close_button=True,
             parent=parent,
         )
         self.text = ""


### PR DESCRIPTION
 

- Fixed widget parent assignments to prevent memory leaks and improve layout cleanup in recipients form
- Removed unused `QStyle` import and replaced standard dialog icons with custom SVG checkmark icon
- Improved spacing/margins handling:
  - Created explicit widget container for amount layout with no-margin wrapper
  - Updated `show_tooltip_after_delay()` to accept optional parent widget for proper cleanup
  - Added parent parameters to widget constructors (`BTCSpinBox`, `AmountAnalyzer`, `QCheckBox`)
- Enabled close button on warning bars
- Updated PR template formatting for AI instruction block

## Required

- `pre-commit install` before any commit. If pre-commit wasn't run for all commits, you can squash all commits   `git reset --soft $(git merge-base main HEAD) && git commit -m "squash"` and ensure the squashed commit is properly formatted
- All commits must be signed. If some are not, you can squash all commits   `git reset --soft $(git merge-base main HEAD) && git commit -m "squash"` and ensure the squashed commit is signed
- [ ] UI/Design/Menu changes **were** tested on _macOS_, because _macOS_ creates endless problems.  Optionally attach a screenshot.
 
## Optional

- [ ] Update all translations
- [ ] Appropriate pytests were added
- [ ] Documentation is updated
- [ ] If this PR affects builds or install artifacts, set the `Build-Relevant` label to trigger build workflows
- [ ] If this PR affects reproducible build outputs, set the `Reproducibility-Relevant` label to trigger the checksum comparison workflow
- [ ] Instruct AI `create a concise summary (bullet points, no stats) for this pr and make a good title`
