### PR TITLE
Harden CLI startup argument parsing

### DIFF
--- a/bitcoin_safe/__main__.py
+++ b/bitcoin_safe/__main__.py
@@ -1,7 +1,4 @@
-import argparse
-import sys
-
-# all import must be absolute, because this is the entry script for pyinstaller
+# Bitcoin Safe
 # Bitcoin Safe
 # Copyright (C) 2023-2026 Andreas Griffin
 #
@@ -29,6 +26,14 @@ import sys
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 #
+
+import argparse
+import logging
+import sys
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+# all import must be absolute, because this is the entry script for pyinstaller
 from bitcoin_safe.logging_setup import setup_logging
 
 setup_logging()
@@ -38,7 +43,7 @@ from bitcoin_safe.dynamic_lib_load import ensure_pyzbar_works, set_os_env_ssl_ce
 set_os_env_ssl_certs()
 ensure_pyzbar_works()
 
-
+import bdkpython as bdk  # noqa: E402
 from PyQt6.QtWidgets import QApplication  # noqa: E402
 
 from bitcoin_safe.compatibility import check_compatibility  # noqa: E402
@@ -47,11 +52,23 @@ from bitcoin_safe.gui.qt.main import MainWindow  # noqa: E402
 from bitcoin_safe.gui.qt.startup_window_probe import StartupWindowProbe  # noqa: E402
 from bitcoin_safe.gui.qt.util import custom_exception_handler  # noqa: E402
 
+logger = logging.getLogger(__name__)
+NETWORK_ARG_NAMES = tuple(sorted(network.name.lower() for network in bdk.Network))
+NETWORK_ARGS = {network_name: bdk.Network[network_name.upper()] for network_name in NETWORK_ARG_NAMES}
 
-def parse_args() -> argparse.Namespace:
-    """Parse args."""
-    parser = argparse.ArgumentParser(description="Bitcoin Safe")
-    parser.add_argument("--network", help="Choose the network: bitcoin, regtest, testnet, signet ")
+
+@dataclass
+class StartupArgs:
+    network: bdk.Network | None
+    profile: bool
+    trace_startup_windows: bool
+    open_files_at_startup: list[str]
+
+
+def create_parser() -> argparse.ArgumentParser:
+    """Create the startup parser."""
+    parser = argparse.ArgumentParser(description="Bitcoin Safe", allow_abbrev=False)
+    parser.add_argument("--network", help=f"Choose the network: {', '.join(NETWORK_ARG_NAMES)}")
     parser.add_argument(
         "--profile", action="store_true", help="Enable profiling. VIsualize with snakeviz .prof_stats"
     )
@@ -67,13 +84,43 @@ def parse_args() -> argparse.Namespace:
         nargs="*",
         help="File to process, can be of type tx, psbt, wallet files.",
     )
+    return parser
 
-    return parser.parse_args()
+
+def sanitize_network_arg(network: str | None) -> bdk.Network | None:
+    """Validate the CLI network value."""
+    if network is None:
+        return None
+    if normalized_network := NETWORK_ARGS.get(network.lower()):
+        return normalized_network
+
+    logger.warning(
+        "Ignoring invalid --network value %r. Accepted values: %s",
+        network,
+        ", ".join(NETWORK_ARG_NAMES),
+    )
+    return None
 
 
-def main() -> None:
+def parse_args(argv: Sequence[str] | None = None) -> StartupArgs:
+    """Parse and sanitize startup args."""
+    parser = create_parser()
+    namespace, unknown_args = parser.parse_known_args(argv)
+
+    if unknown_args:
+        logger.warning("Ignoring unknown startup arguments: %s", unknown_args)
+
+    return StartupArgs(
+        network=sanitize_network_arg(namespace.network),
+        profile=namespace.profile,
+        trace_startup_windows=namespace.trace_startup_windows,
+        open_files_at_startup=list(namespace.open_files_at_startup),
+    )
+
+
+def main(args: StartupArgs | None = None) -> None:
     """Main."""
-    args = parse_args()
+    startup_args = args if args is not None else parse_args()
 
     sys.excepthook = custom_exception_handler
     app = QApplication(sys.argv)
@@ -86,8 +133,11 @@ def main() -> None:
     if is_gnome_dark_mode():
         set_dark_palette(app)
 
-    window = MainWindow(**vars(args))
-    if args.trace_startup_windows:
+    window = MainWindow(
+        network=startup_args.network,
+        open_files_at_startup=startup_args.open_files_at_startup,
+    )
+    if startup_args.trace_startup_windows:
         app._startup_window_probe = StartupWindowProbe(app=app, expected_main_window=window)  # type: ignore
     window.show()
     app.exec()
@@ -97,15 +147,15 @@ def main() -> None:
 # open in https://www.speedscope.app/
 
 if __name__ == "__main__":
-    args = parse_args()
+    startup_args = parse_args()
 
-    if args.profile:
+    if startup_args.profile:
         import cProfile
         import os
         from pstats import Stats
 
         with cProfile.Profile() as pr:
-            main()
+            main(startup_args)
 
         # run in bash "snakeviz .prof_stats &"  to visualize the stats
         with open("profiling_stats.txt", "w") as stream:
@@ -116,4 +166,4 @@ if __name__ == "__main__":
             os.system("snakeviz .prof_stats & ")
             # os.system("pyprof2calltree -i .prof_stats -k & ")
     else:
-        main()
+        main(startup_args)

--- a/bitcoin_safe/gui/qt/main.py
+++ b/bitcoin_safe/gui/qt/main.py
@@ -42,7 +42,7 @@ from functools import partial
 from json import JSONDecodeError
 from pathlib import Path
 from types import FrameType
-from typing import Literal, cast
+from typing import cast
 
 import bdkpython as bdk
 from bitcoin_qr_tools.data import Data, DataType
@@ -181,7 +181,7 @@ class MainWindow(UnlockableMainWindow):
 
     def __init__(
         self,
-        network: Literal["bitcoin", "regtest", "signet", "testnet"] | None = None,
+        network: bdk.Network | None = None,
         config: UserConfig | None = None,
         open_files_at_startup: list[str] | None = None,
         **kwargs,
@@ -197,7 +197,7 @@ class MainWindow(UnlockableMainWindow):
         else:
             logger.debug("UserConfig will be created new")
         self.config = config if config else UserConfig.from_file()
-        self.config.network = bdk.Network[network.upper()] if network else self.config.network
+        self.config.network = network if network else self.config.network
         self.external_registry = ExternalPluginRegistry.from_config(self.config)
         self.new_startup_network: bdk.Network | None = None
         self._before_close_was_run = False

--- a/bitcoin_safe/logging_setup.py
+++ b/bitcoin_safe/logging_setup.py
@@ -46,6 +46,8 @@ from bitcoin_safe.logging_handlers import (
     RelativePathFormatter,
 )
 
+_LOGGING_CONFIGURED = False
+
 
 def get_config_dir() -> Path:
     """Get config dir."""
@@ -63,6 +65,10 @@ def get_log_file() -> Path:
 def setup_logging() -> None:
     # Configuring formatters
     """Setup logging."""
+    global _LOGGING_CONFIGURED
+    if _LOGGING_CONFIGURED:
+        return
+
     relative_path_formatter = RelativePathFormatter(
         fmt="%(asctime)s - %(levelname)s - [%(threadName)s] - %(name)s - %(message)s"
     )
@@ -77,9 +83,7 @@ def setup_logging() -> None:
     file_handler.setLevel(logging.DEBUG)
     file_handler.setFormatter(relative_path_formatter)
 
-    mail_handler = (
-        MailHandler()
-    )  # Assuming MailHandler is correctly implemented in bitcoin_safe.logging_handlers
+    mail_handler = MailHandler()
     mail_handler.setLevel(logging.CRITICAL)
     mail_handler.setFormatter(relative_path_formatter)
     # Assuming 'must_include_exc_info' is handled internally in the MailHandler implementation
@@ -121,6 +125,8 @@ def setup_logging() -> None:
 
     # Install the message handler as early as possible
     qInstallMessageHandler(qt_message_handler)
+
+    _LOGGING_CONFIGURED = True
 
     logger.info("========================= Starting Bitcoin Safe ========================")
     logger.info(f"Version: {__version__}")

--- a/tests/non_gui/test_mail_handler.py
+++ b/tests/non_gui/test_mail_handler.py
@@ -36,6 +36,7 @@ from unittest.mock import patch
 from _pytest.logging import LogCaptureFixture
 
 from bitcoin_safe.logging_handlers import mail_error_repot, text_error_report
+from bitcoin_safe.logging_setup import setup_logging
 
 logger = logging.getLogger(__name__)
 
@@ -73,6 +74,23 @@ def test_exception_logging(caplog: LogCaptureFixture) -> None:
                 mock_compose_email.assert_called_once()
                 # Assert that the mocked function was called
                 mock_OpenLogHandler_emit.assert_called_once()
+
+
+def test_setup_logging_is_idempotent(caplog: LogCaptureFixture) -> None:
+    """Repeated setup_logging calls must not duplicate error handlers."""
+    setup_logging()
+    setup_logging()
+
+    with patch("bitcoin_safe.logging_handlers.OpenLogHandler.emit") as mock_open_log_handler_emit:
+        mock_open_log_handler_emit.return_value = "Mocked OpenLogHandler.emit"
+        with patch("bitcoin_safe.logging_handlers.compose_email") as mock_compose_email:
+            mock_compose_email.return_value = "Mocked Function"
+
+            with caplog.at_level(logging.INFO):
+                logger.critical("this should compose an email", exc_info=sys.exc_info())
+
+            mock_compose_email.assert_called_once()
+            mock_open_log_handler_emit.assert_called_once()
 
 
 def test_text_error_report_includes_plugin_diagnostics() -> None:

--- a/tests/test_main_startup_args.py
+++ b/tests/test_main_startup_args.py
@@ -1,0 +1,100 @@
+#
+# Bitcoin Safe
+# Copyright (C) 2026 Andreas Griffin
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of version 3 of the GNU General Public License as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see https://www.gnu.org/licenses/gpl-3.0.html
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+# BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+# ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import Mock, patch
+
+import bdkpython as bdk
+from _pytest.logging import LogCaptureFixture
+
+import bitcoin_safe.__main__ as app_main
+
+
+def test_parse_args_keeps_valid_network() -> None:
+    """Test valid network values are preserved."""
+    startup_args = app_main.parse_args(["--network", "bitcoin"])
+
+    assert startup_args.network == bdk.Network.BITCOIN
+
+
+def test_parse_args_keeps_testnet4_network() -> None:
+    """Test testnet4 stays supported."""
+    startup_args = app_main.parse_args(["--network", "testnet4"])
+
+    assert startup_args.network == bdk.Network.TESTNET4
+
+
+def test_parse_args_ignores_invalid_network(caplog: LogCaptureFixture) -> None:
+    """Test invalid network values are ignored with a warning."""
+    with caplog.at_level(logging.WARNING, logger=app_main.__name__):
+        startup_args = app_main.parse_args(["--network", "main"])
+
+    assert startup_args.network is None
+    assert "Ignoring invalid --network value 'main'" in caplog.text
+    assert "bitcoin, regtest, signet, testnet, testnet4" in caplog.text
+
+
+def test_parse_args_ignores_unknown_flags(caplog: LogCaptureFixture) -> None:
+    """Test unknown flags are logged and ignored."""
+    with caplog.at_level(logging.WARNING, logger=app_main.__name__):
+        startup_args = app_main.parse_args(["--profile", "--foo", "wallet.psbt"])
+
+    assert startup_args.profile is True
+    assert startup_args.open_files_at_startup == ["wallet.psbt"]
+    assert "Ignoring unknown startup arguments" in caplog.text
+    assert "--foo" in caplog.text
+
+
+def test_parse_args_keeps_file_arguments() -> None:
+    """Test positional startup files are preserved."""
+    startup_args = app_main.parse_args(["file1.wallet", "file2.psbt"])
+
+    assert startup_args.open_files_at_startup == ["file1.wallet", "file2.psbt"]
+
+
+def test_main_uses_sanitized_network() -> None:
+    """Test main forwards the sanitized network to MainWindow."""
+    startup_args = app_main.parse_args(["--network", "main", "wallet.psbt"])
+    app = Mock()
+    window = Mock()
+
+    with (
+        patch.object(app_main, "QApplication", return_value=app),
+        patch.object(app_main, "check_compatibility"),
+        patch.object(app_main, "is_gnome_dark_mode", return_value=False),
+        patch.object(app_main, "set_dark_palette"),
+        patch.object(app_main, "MainWindow", return_value=window) as main_window_cls,
+    ):
+        app_main.main(startup_args)
+
+    main_window_cls.assert_called_once_with(network=None, open_files_at_startup=["wallet.psbt"])
+    window.show.assert_called_once()
+    app.exec.assert_called_once()


### PR DESCRIPTION

- Refactors CLI argument parsing to validate and sanitize network arguments before use
- Introduces a `StartupArgs` dataclass to properly type startup parameters
- Prevents invalid `--network` values and logs warnings instead of crashing; normalizes case-insensitive input
- Disables abbreviations in argparse to avoid unexpected flag matching
- Handles unknown arguments gracefully by logging and ignoring them
- Updates `MainWindow` to accept `bdk.Network` enum directly instead of string conversion
- Adds comprehensive tests covering valid/invalid networks, unknown flags, and file arguments

## Required

- `pre-commit install` before any commit. If pre-commit wasn't run for all commits, you can squash all commits   `git reset --soft $(git merge-base main HEAD) && git commit -m "squash"` and ensure the squashed commit is properly formatted
- All commits must be signed. If some are not, you can squash all commits   `git reset --soft $(git merge-base main HEAD) && git commit -m "squash"` and ensure the squashed commit is signed
- [ ] UI/Design/Menu changes **were** tested on _macOS_, because _macOS_ creates endless problems.  Optionally attach a screenshot.
 
## Optional

- [ ] Update all translations
- [ ] Appropriate pytests were added
- [ ] Documentation is updated
- [ ] If this PR affects builds or install artifacts, set the `Build-Relevant` label to trigger build workflows
- [ ] If this PR affects reproducible build outputs, set the `Reproducibility-Relevant` label to trigger the checksum comparison workflow
- [ ] Instruct AI 
```
create a concise summary (bullet points, no stats) for this pr and make a good title
```
