### PR TITLE
Fix Windows TreeView selection text visibility

### DIFF
--- a/bitcoin_safe/gui/qt/color_corrected_treeview.py
+++ b/bitcoin_safe/gui/qt/color_corrected_treeview.py
@@ -1,0 +1,121 @@
+#
+# Bitcoin Safe
+# Copyright (C) 2026 Andreas Griffin
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of version 3 of the GNU General Public License as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see https://www.gnu.org/licenses/gpl-3.0.html
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+# BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+# ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
+from __future__ import annotations
+
+from PyQt6.QtCore import QEvent
+from PyQt6.QtWidgets import QTreeView, QWidget
+
+
+class ColorCorrectedTreeView(QTreeView):
+    """QTreeView variant that fixes selected item text colors for Windows styles."""
+
+    _SELECTION_STYLE_MARKER_START = "/* colorcorrectedtreeview-selection-override:start */"
+    _SELECTION_STYLE_MARKER_END = "/* colorcorrectedtreeview-selection-override:end */"
+    _WINDOWS_STYLE_NAMES = frozenset({"windows", "windowsvista", "windows11"})
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        """Initialize instance."""
+        super().__init__(parent)
+        self.setObjectName(f"{self.__class__.__name__}.{id(self)}")
+        self._refresh_selection_style_sheet()
+
+    def changeEvent(self, event: QEvent | None) -> None:
+        """React to palette and style changes that affect selection colors."""
+        super().changeEvent(event)
+        if not event:
+            return
+        if event.type() in {QEvent.Type.StyleChange, QEvent.Type.PaletteChange}:
+            self._refresh_selection_style_sheet()
+
+    def setStyleSheet(self, styleSheet: str | None) -> None:
+        """Keep the managed selection override when other code updates the stylesheet."""
+        base_style_sheet = self._strip_selection_style_override(styleSheet or "")
+        super().setStyleSheet(self._compose_selection_style_sheet(base_style_sheet))
+
+    def _needs_selection_text_override(self) -> bool:
+        """Return whether the current Qt style needs an explicit selection text override."""
+        style_names: set[str] = set()
+        style = self.style()
+        if not style:
+            return False
+        style_names.add(style.objectName().lower())
+        if meta_object := style.metaObject():
+            style_names.add(meta_object.className().lower())
+
+        return any(
+            windows_style_name in style_name
+            for style_name in style_names
+            for windows_style_name in self._WINDOWS_STYLE_NAMES
+        )
+
+    def _selection_style_override(self) -> str:
+        """Return the guarded selection-color override stylesheet."""
+        palette = self.palette()
+        selection_color = palette.color(palette.ColorRole.HighlightedText).name()
+        tree_view_selector = f'QTreeView[objectName="{self.objectName()}"]'
+        return f"""
+{self._SELECTION_STYLE_MARKER_START}
+{tree_view_selector}::item:selected {{
+    color: {selection_color};
+}}
+{tree_view_selector}::item:selected:active {{
+    color: {selection_color};
+}}
+{tree_view_selector}::item:selected:!active {{
+    color: {selection_color};
+}}
+{self._SELECTION_STYLE_MARKER_END}
+""".strip()
+
+    def _strip_selection_style_override(self, style_sheet: str) -> str:
+        """Remove the managed selection override block from a stylesheet."""
+        if self._SELECTION_STYLE_MARKER_START not in style_sheet:
+            return style_sheet
+
+        prefix, _, rest = style_sheet.partition(self._SELECTION_STYLE_MARKER_START)
+        _, _, suffix = rest.partition(self._SELECTION_STYLE_MARKER_END)
+        return f"{prefix.rstrip()}\n{suffix.lstrip()}".strip()
+
+    def _compose_selection_style_sheet(self, base_style_sheet: str) -> str:
+        """Append the managed selection override when the current style needs it."""
+        if not self._needs_selection_text_override():
+            return base_style_sheet.strip()
+
+        return "\n\n".join(
+            style for style in [base_style_sheet.strip(), self._selection_style_override()] if style
+        )
+
+    def _refresh_selection_style_sheet(self) -> None:
+        """Rebuild the managed selection override using the current palette and style."""
+        current_style_sheet = super().styleSheet()
+        base_style_sheet = self._strip_selection_style_override(current_style_sheet)
+        new_style_sheet = self._compose_selection_style_sheet(base_style_sheet)
+        if new_style_sheet != current_style_sheet:
+            super().setStyleSheet(new_style_sheet)

--- a/bitcoin_safe/gui/qt/my_treeview.py
+++ b/bitcoin_safe/gui/qt/my_treeview.py
@@ -135,6 +135,7 @@ from bitcoin_safe.wallet import TxStatus
 
 from ...config import UserConfig
 from ...i18n import translate
+from .color_corrected_treeview import ColorCorrectedTreeView
 from .util import do_copy, set_no_margins
 
 logger = logging.getLogger(__name__)
@@ -557,7 +558,7 @@ class DropRule(NamedTuple):
     handler: Callable[[QTreeView, QDropEvent, QModelIndex], None]
 
 
-class MyTreeView(QTreeView, BaseSaveableClass, Generic[T]):
+class MyTreeView(ColorCorrectedTreeView, BaseSaveableClass, Generic[T]):
     signal_selection_changed = cast(SignalProtocol[[]], pyqtSignal())
     signal_update = cast(SignalProtocol[[]], pyqtSignal())
     signal_finished_update = cast(SignalProtocol[[]], pyqtSignal())

--- a/tests/gui/qt/test_my_treeview.py
+++ b/tests/gui/qt/test_my_treeview.py
@@ -36,6 +36,7 @@ from PyQt6.QtGui import QStandardItem
 from pytestqt.qtbot import QtBot
 
 from bitcoin_safe.config import UserConfig
+from bitcoin_safe.gui.qt.color_corrected_treeview import ColorCorrectedTreeView
 from bitcoin_safe.gui.qt.my_treeview import MyItemDataRole, MyTreeView
 from bitcoin_safe.signals import Signals
 
@@ -86,3 +87,52 @@ def test_mytreeview_filter_matches_clipboard_content(qtbot: QtBot, test_config: 
 
     assert tree_view.filter("plain") == [True, True, True, False]
     assert not _is_hidden(tree_view, 3)
+
+
+def test_mytreeview_selection_override_not_applied_for_non_windows_style(
+    monkeypatch, qtbot: QtBot, test_config: UserConfig
+) -> None:
+    tree_view = DummyTreeView(config=test_config)
+    qtbot.addWidget(tree_view)
+    tree_view.setStyleSheet("QTreeView { border: none; }")
+
+    monkeypatch.setattr(tree_view, "_needs_selection_text_override", lambda: False)
+
+    tree_view._refresh_selection_style_sheet()
+
+    assert tree_view.styleSheet() == "QTreeView { border: none; }"
+
+
+def test_mytreeview_selection_override_applied_for_windows_style(
+    monkeypatch, qtbot: QtBot, test_config: UserConfig
+) -> None:
+    tree_view = DummyTreeView(config=test_config)
+    qtbot.addWidget(tree_view)
+
+    monkeypatch.setattr(tree_view, "_needs_selection_text_override", lambda: True)
+
+    tree_view._refresh_selection_style_sheet()
+
+    palette = tree_view.palette()
+    selection_color = palette.color(palette.ColorRole.HighlightedText).name()
+    selector = f'QTreeView[objectName="{tree_view.objectName()}"]::item:selected'
+
+    assert f"color: {selection_color};" in tree_view.styleSheet()
+    assert "background-color:" not in tree_view.styleSheet()
+    assert selector in tree_view.styleSheet()
+    assert tree_view.objectName().startswith("DummyTreeView.")
+
+
+def test_colorcorrectedtreeview_keeps_managed_override_when_stylesheet_changes(
+    monkeypatch, qtbot: QtBot
+) -> None:
+    tree_view = ColorCorrectedTreeView()
+    qtbot.addWidget(tree_view)
+
+    monkeypatch.setattr(tree_view, "_needs_selection_text_override", lambda: True)
+
+    tree_view.setStyleSheet("QTreeView { border: none; }")
+
+    assert "QTreeView { border: none; }" in tree_view.styleSheet()
+    assert f'QTreeView[objectName="{tree_view.objectName()}"]::item:selected' in tree_view.styleSheet()
+    assert tree_view.objectName().startswith("ColorCorrectedTreeView.")

--- a/tools/test_treeview_selection_colors.py
+++ b/tools/test_treeview_selection_colors.py
@@ -1,0 +1,140 @@
+#
+# Bitcoin Safe
+# Copyright (C) 2026 Andreas Griffin
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of version 3 of the GNU General Public License as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see https://www.gnu.org/licenses/gpl-3.0.html
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+# BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+# ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
+from __future__ import annotations
+
+import argparse
+import sys
+import tempfile
+from pathlib import Path
+
+from PyQt6.QtGui import QBrush, QColor, QImage, QPainter, QStandardItem, QStandardItemModel
+from PyQt6.QtWidgets import QApplication, QStyleFactory, QTreeView
+
+from bitcoin_safe.gui.qt.color_corrected_treeview import ColorCorrectedTreeView
+
+
+def build_view(tree_view: QTreeView) -> QTreeView:
+    model = QStandardItemModel()
+    item = QStandardItem("MMMM Selected Text MMMM")
+    item.setForeground(QBrush(QColor("black")))
+    model.appendRow([item])
+
+    tree_view.setSelectionBehavior(QTreeView.SelectionBehavior.SelectRows)
+    tree_view.setModel(model)
+
+    selection_model = tree_view.selectionModel()
+    assert selection_model is not None
+    selection_model.select(
+        model.index(0, 0),
+        selection_model.SelectionFlag.Select | selection_model.SelectionFlag.Rows,
+    )
+    return tree_view
+
+
+def render_view(tree_view: QTreeView, target: Path) -> QImage:
+    tree_view.resize(420, 120)
+    tree_view.show()
+    QApplication.processEvents()
+
+    viewport = tree_view.viewport()
+    if not viewport:
+        return QImage()
+    image = QImage(viewport.size(), QImage.Format.Format_ARGB32)
+    image.fill(viewport.palette().base().color())
+    painter = QPainter(image)
+    viewport.render(painter)
+    painter.end()
+    image.save(str(target))
+    tree_view.close()
+    return image
+
+
+def images_differ(left: QImage, right: QImage) -> bool:
+    if left.size() != right.size():
+        return True
+
+    for y in range(left.height()):
+        for x in range(left.width()):
+            if left.pixel(x, y) != right.pixel(x, y):
+                return True
+    return False
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path(tempfile.mkdtemp(prefix="treeview-selection-demo-")),
+        help="Directory where the rendered screenshots are written.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+
+    app = QApplication.instance() or QApplication(sys.argv)
+    available_styles = {name.lower() for name in QStyleFactory.keys()}
+    if "windows11" not in available_styles:
+        print("windows11 Qt style is not available on this machine.")
+        return 1
+
+    old_style = app.style()  # type: ignore
+    old_style_name = old_style.objectName() if old_style else ""
+    windows11_style = QStyleFactory.create("windows11")
+    assert windows11_style is not None
+    app.setStyle(windows11_style)  # type: ignore
+
+    try:
+        broken_view = build_view(QTreeView())
+        corrected_view = build_view(ColorCorrectedTreeView())
+
+        broken_path = args.output_dir / "native_background_black_text.png"
+        corrected_path = args.output_dir / "native_background_white_text.png"
+
+        broken_image = render_view(broken_view, broken_path)
+        corrected_image = render_view(corrected_view, corrected_path)
+    finally:
+        if old_style_name:
+            restored_style = QStyleFactory.create(old_style_name)
+            if restored_style is not None:
+                app.setStyle(restored_style)  # type: ignore
+
+    differs = images_differ(broken_image, corrected_image)
+    print(f"Broken render:    {broken_path}")
+    print(f"Corrected render: {corrected_path}")
+    print(f"Images differ:    {differs}")
+    return 0 if differs else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION


- **Problem**: Selected text in tree views becomes invisible on Windows styles (Windows 11, WindowsVista) due to conflicting text and background colors
- **Solution**: Introduces `ColorCorrectedTreeView`, a new QTreeView subclass that automatically injects stylesheet overrides to ensure selected text remains visible
- **Implementation**: Detects Windows-style renderers and applies dynamic text-color overrides that persist across style and palette changes
- **Coverage**: Adds comprehensive unit tests and a visual test tool for validation across different Qt styles
- **Changes**: 4 files modified (new `ColorCorrectedTreeView` class, `MyTreeView` inheritance updated, test coverage added, demo tool added)

## Required

- `pre-commit install` before any commit. If pre-commit wasn't run for all commits, you can squash all commits   `git reset --soft $(git merge-base main HEAD) && git commit -m "squash"` and ensure the squashed commit is properly formatted
- All commits must be signed. If some are not, you can squash all commits   `git reset --soft $(git merge-base main HEAD) && git commit -m "squash"` and ensure the squashed commit is signed
- [ ] UI/Design/Menu changes **were** tested on _macOS_, because _macOS_ creates endless problems.  Optionally attach a screenshot.
 
## Optional

- [ ] Update all translations
- [ ] Appropriate pytests were added
- [ ] Documentation is updated
- [ ] If this PR affects builds or install artifacts, set the `Build-Relevant` label to trigger build workflows
- [ ] If this PR affects reproducible build outputs, set the `Reproducibility-Relevant` label to trigger the checksum comparison workflow
- [ ] Instruct AI 
```
create a concise summary (bullet points, no stats) for this pr and make a good title
```
