### PR TITLE
CI: Trigger reproducibility check on tag push

### DIFF
--- a/.github/workflows/check-build-reproducibility.yml
+++ b/.github/workflows/check-build-reproducibility.yml
@@ -9,6 +9,9 @@ on:
         description: "Enter the commit hash to build twice (leave empty to use the current branch HEAD)"
         required: false
         type: string
+  push:
+    tags:
+      - "**"
   pull_request:
     types:
       - opened
@@ -18,25 +21,25 @@ on:
 
 jobs:
   linux-run-1:
-    if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'Reproducibility-Relevant')) }}
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'push' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'Reproducibility-Relevant')) }}
     uses: ./.github/workflows/build-appimage-and-test.yml
     with:
-      commitHash: ${{ github.event_name == 'workflow_dispatch' && inputs.commitHash || github.event.pull_request.head.sha || '' }}
+      commitHash: ${{ github.event_name == 'workflow_dispatch' && inputs.commitHash || github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.event_name == 'push' && github.sha || '' }}
       artifact_name_prefix: repro-linux-run-1-
       run_tests: false
     secrets: inherit
 
   linux-run-2:
-    if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'Reproducibility-Relevant')) }}
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'push' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'Reproducibility-Relevant')) }}
     uses: ./.github/workflows/build-appimage-and-test.yml
     with:
-      commitHash: ${{ github.event_name == 'workflow_dispatch' && inputs.commitHash || github.event.pull_request.head.sha || '' }}
+      commitHash: ${{ github.event_name == 'workflow_dispatch' && inputs.commitHash || github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.event_name == 'push' && github.sha || '' }}
       artifact_name_prefix: repro-linux-run-2-
       run_tests: false
     secrets: inherit
 
   compare-linux:
-    if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'Reproducibility-Relevant')) }}
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'push' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'Reproducibility-Relevant')) }}
     needs:
       - linux-run-1
       - linux-run-2
@@ -128,25 +131,25 @@ jobs:
           exit 1
 
   flatpak-run-1:
-    if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'Reproducibility-Relevant')) }}
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'push' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'Reproducibility-Relevant')) }}
     uses: ./.github/workflows/build-flatpak-and-test.yml
     with:
-      commitHash: ${{ github.event_name == 'workflow_dispatch' && inputs.commitHash || github.event.pull_request.head.sha || '' }}
+      commitHash: ${{ github.event_name == 'workflow_dispatch' && inputs.commitHash || github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.event_name == 'push' && github.sha || '' }}
       artifact_name_prefix: repro-flatpak-run-1-
       run_tests: false
     secrets: inherit
 
   flatpak-run-2:
-    if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'Reproducibility-Relevant')) }}
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'push' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'Reproducibility-Relevant')) }}
     uses: ./.github/workflows/build-flatpak-and-test.yml
     with:
-      commitHash: ${{ github.event_name == 'workflow_dispatch' && inputs.commitHash || github.event.pull_request.head.sha || '' }}
+      commitHash: ${{ github.event_name == 'workflow_dispatch' && inputs.commitHash || github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.event_name == 'push' && github.sha || '' }}
       artifact_name_prefix: repro-flatpak-run-2-
       run_tests: false
     secrets: inherit
 
   compare-flatpak:
-    if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'Reproducibility-Relevant')) }}
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'push' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'Reproducibility-Relevant')) }}
     needs:
       - flatpak-run-1
       - flatpak-run-2
@@ -176,25 +179,25 @@ jobs:
             --label Flatpak
 
   windows-run-1:
-    if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'Reproducibility-Relevant')) }}
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'push' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'Reproducibility-Relevant')) }}
     uses: ./.github/workflows/build-windows-and-test.yml
     with:
-      commitHash: ${{ github.event_name == 'workflow_dispatch' && inputs.commitHash || github.event.pull_request.head.sha || '' }}
+      commitHash: ${{ github.event_name == 'workflow_dispatch' && inputs.commitHash || github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.event_name == 'push' && github.sha || '' }}
       artifact_name_prefix: repro-windows-run-1-
       run_tests: false
     secrets: inherit
 
   windows-run-2:
-    if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'Reproducibility-Relevant')) }}
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'push' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'Reproducibility-Relevant')) }}
     uses: ./.github/workflows/build-windows-and-test.yml
     with:
-      commitHash: ${{ github.event_name == 'workflow_dispatch' && inputs.commitHash || github.event.pull_request.head.sha || '' }}
+      commitHash: ${{ github.event_name == 'workflow_dispatch' && inputs.commitHash || github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.event_name == 'push' && github.sha || '' }}
       artifact_name_prefix: repro-windows-run-2-
       run_tests: false
     secrets: inherit
 
   compare-windows:
-    if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'Reproducibility-Relevant')) }}
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'push' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'Reproducibility-Relevant')) }}
     needs:
       - windows-run-1
       - windows-run-2


### PR DESCRIPTION

- Auto check reproducibility 

 

## Required

- `pre-commit install` before any commit. If pre-commit wasn't run for all commits, you can squash all commits   `git reset --soft $(git merge-base main HEAD) && git commit -m "squash"` and ensure the squashed commit is properly formatted
- All commits must be signed. If some are not, you can squash all commits   `git reset --soft $(git merge-base main HEAD) && git commit -m "squash"` and ensure the squashed commit is signed
- [ ] UI/Design/Menu changes **were** tested on _macOS_, because _macOS_ creates endless problems.  Optionally attach a screenshot.
 
## Optional

- [ ] Update all translations
- [ ] Appropriate pytests were added
- [ ] Documentation is updated
- [ ] If this PR affects builds or install artifacts, set the `Build-Relevant` label to trigger build workflows
- [ ] If this PR affects reproducible build outputs, set the `Reproducibility-Relevant` label to trigger the checksum comparison workflow
- [ ] Instruct AI 
```
create a concise summary (bullet points, no stats) for this pr and make a good title
```
