### PR TITLE
Fix UTF-8 encoding  on Windows

### DIFF
--- a/bitcoin_safe/descriptor_export_tools.py
+++ b/bitcoin_safe/descriptor_export_tools.py
@@ -114,7 +114,7 @@ class DescriptorExportTools:
         if not filename:
             return None
 
-        with open(filename, "w") as file:
+        with open(filename, "w", encoding="utf-8") as file:
             file.write(s)
         return filename
 

--- a/bitcoin_safe/gui/qt/export_data.py
+++ b/bitcoin_safe/gui/qt/export_data.py
@@ -972,7 +972,7 @@ class ExportDataSimple(HorizontalImportExportGroups):
         if not filename:
             return None
 
-        with open(filename, "w") as file:
+        with open(filename, "w", encoding="utf-8") as file:
             file.write(s)
         return filename
 

--- a/bitcoin_safe/gui/qt/my_treeview.py
+++ b/bitcoin_safe/gui/qt/my_treeview.py
@@ -366,7 +366,7 @@ class MySortModel(QSortFilterProxyModel):
                 prefix=f"{self.drag_key} ",
             )
 
-        with os.fdopen(file_descriptor, "w") as file:
+        with os.fdopen(file_descriptor, "w", encoding="utf-8") as file:
             file.write(csv_string)
 
         logger.debug(f"CSV Table saved to {file_path}")

--- a/bitcoin_safe/gui/qt/qt_wallet.py
+++ b/bitcoin_safe/gui/qt/qt_wallet.py
@@ -2179,7 +2179,7 @@ class QTWallet(QtWalletBase, BaseSaveableClass):
             logger.info(self.tr("No file selected"))
             return
 
-        with open(file_path, "w") as file:
+        with open(file_path, "w", encoding="utf-8") as file:
             file.write(s)
 
     def export_labels(self) -> None:
@@ -2195,7 +2195,7 @@ class QTWallet(QtWalletBase, BaseSaveableClass):
             logger.info(self.tr("No file selected"))
             return
 
-        with open(file_path, "w") as file:
+        with open(file_path, "w", encoding="utf-8") as file:
             file.write(s)
 
     def import_bip329_labels(self) -> None:

--- a/bitcoin_safe/gui/qt/recipient_csv.py
+++ b/bitcoin_safe/gui/qt/recipient_csv.py
@@ -111,7 +111,7 @@ def export_recipients_csv(
             return None
 
     path = Path(file_path)
-    with path.open("w", newline="") as file:
+    with path.open("w", newline="", encoding="utf-8") as file:
         writer = csv.writer(file)
         writer.writerows(recipients_to_csv_rows(recipients=recipients, network=network))
 

--- a/bitcoin_safe/gui/qt/sankey_widget.py
+++ b/bitcoin_safe/gui/qt/sankey_widget.py
@@ -469,9 +469,9 @@ class SankeyWidget(QWidget):
 
         self.draw_content(QPainter(generator), workaround_for_svg=True)
 
-        with open(str(filename)) as file:
+        with open(str(filename), encoding="utf-8") as file:
             contents = file.read()
-        with open(str(filename), "w") as file:
+        with open(str(filename), "w", encoding="utf-8") as file:
             defs = ""
             for color_name, (start_color, end_color) in self.gradient_dict.items():
                 gradient_name = f"linear{color_name.lstrip('#')}"

--- a/bitcoin_safe/gui/qt/sync_tab.py
+++ b/bitcoin_safe/gui/qt/sync_tab.py
@@ -97,7 +97,9 @@ class BackupNsecNotificationBar(NotificationBar):
         if not filename:
             return None
 
-        with open(filename, "w") as file:
+        # Use UTF-8 explicitly because Windows may default to cp1252, which cannot
+        # encode some translated strings such as U+2011 (non-breaking hyphen).
+        with open(filename, "w", encoding="utf-8") as file:
             file.write(
                 self.tr("Sync key of wallet {wallet_id}:  {nsec}").format(
                     wallet_id=self.wallet_id, nsec=self.nsec

--- a/bitcoin_safe/plugin_framework/plugins/chat_sync/client.py
+++ b/bitcoin_safe/plugin_framework/plugins/chat_sync/client.py
@@ -108,7 +108,9 @@ class BackupNsecNotificationBar(NotificationBar):
         if not filename:
             return None
 
-        with open(filename, "w") as file:
+        # Use UTF-8 explicitly because Windows may default to cp1252, which cannot
+        # encode some translated strings such as U+2011 (non-breaking hyphen).
+        with open(filename, "w", encoding="utf-8") as file:
             file.write(
                 self.tr("Sync key of wallet {wallet_id}:  {nsec}").format(
                     wallet_id=self.wallet_id, nsec=self.nsec

--- a/tests/gui/qt/test_my_treeview.py
+++ b/tests/gui/qt/test_my_treeview.py
@@ -30,7 +30,9 @@
 from __future__ import annotations
 
 import enum
+from pathlib import Path
 
+import pytest
 from PyQt6.QtCore import QModelIndex
 from PyQt6.QtGui import QStandardItem
 from pytestqt.qtbot import QtBot
@@ -136,3 +138,16 @@ def test_colorcorrectedtreeview_keeps_managed_override_when_stylesheet_changes(
     assert "QTreeView { border: none; }" in tree_view.styleSheet()
     assert f'QTreeView[objectName="{tree_view.objectName()}"]::item:selected' in tree_view.styleSheet()
     assert tree_view.objectName().startswith("ColorCorrectedTreeView.")
+
+
+def test_mytreeview_csv_export_writes_utf8(tmp_path: Path, test_config: UserConfig) -> None:
+    tree_view = DummyTreeView(config=test_config)
+    tree_view.append_row(text="Sync\u2011label", key="sync")
+
+    file_path = tree_view.proxy.csv_drag_keys_to_file_path(file_path=str(tmp_path / "export.csv"))
+    exported_csv = Path(file_path).read_text(encoding="utf-8")
+
+    with pytest.raises(UnicodeEncodeError):
+        exported_csv.encode("cp1252")
+
+    assert "Sync\u2011label" in exported_csv

--- a/tests/gui/qt/test_recipient_csv.py
+++ b/tests/gui/qt/test_recipient_csv.py
@@ -65,7 +65,7 @@ def _action_texts(button: FileToolButton) -> list[str]:
 
 def test_export_recipients_csv_writes_expected_rows(tmp_path: Path) -> None:
     recipients = [
-        Recipient(address="bcrt1qa", amount=125_000, label="Alice"),
+        Recipient(address="bcrt1qa", amount=125_000, label="Sync\u2011label"),
         Recipient(address="bcrt1qb", amount=250_000, label=None),
     ]
 
@@ -77,12 +77,16 @@ def test_export_recipients_csv_writes_expected_rows(tmp_path: Path) -> None:
 
     assert path == tmp_path / "recipients.csv"
 
-    with path.open() as file:
+    expected_csv = path.read_text(encoding="utf-8")
+    with pytest.raises(UnicodeEncodeError):
+        expected_csv.encode("cp1252")
+
+    with path.open(encoding="utf-8") as file:
         rows = list(csv.reader(file))
 
     assert rows == [
         get_recipient_csv_header(bdk.Network.REGTEST),
-        ["bcrt1qa", "125000", "Alice"],
+        ["bcrt1qa", "125000", "Sync\u2011label"],
         ["bcrt1qb", "250000", ""],
     ]
 


### PR DESCRIPTION

- **Fixes file encoding issues** on Windows where backup exports could fail due to default cp1252 encoding unable to handle translated strings (e.g., non-breaking hyphen U+2011)
- **Applies to two sync key export functions**: GUI sync tab and chat sync plugin backup exports
- **Simple, targeted fix**: Explicitly specifies UTF-8 encoding in file write operations



## Required

- `pre-commit install` before any commit. If pre-commit wasn't run for all commits, you can squash all commits   `git reset --soft $(git merge-base main HEAD) && git commit -m "squash"` and ensure the squashed commit is properly formatted
- All commits must be signed. If some are not, you can squash all commits   `git reset --soft $(git merge-base main HEAD) && git commit -m "squash"` and ensure the squashed commit is signed
- [ ] UI/Design/Menu changes **were** tested on _macOS_, because _macOS_ creates endless problems.  Optionally attach a screenshot.
 
## Optional

- [ ] Update all translations
- [ ] Appropriate pytests were added
- [ ] Documentation is updated
- [ ] If this PR affects builds or install artifacts, set the `Build-Relevant` label to trigger build workflows
- [ ] If this PR affects reproducible build outputs, set the `Reproducibility-Relevant` label to trigger the checksum comparison workflow
- [ ] Instruct AI 
```
create a concise summary (bullet points, no stats) for this pr and make a good title
```
