### PR TITLE
Fix pyinstaller packaging: hidden imports for plugins

### DIFF
--- a/tests/non_gui/test_build_pyinstaller_hiddenimports.py
+++ b/tests/non_gui/test_build_pyinstaller_hiddenimports.py
@@ -1,0 +1,69 @@
+#
+# Bitcoin Safe
+# Copyright (C) 2026 Andreas Griffin
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of version 3 of the GNU General Public License as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see https://www.gnu.org/licenses/gpl-3.0.html
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+# BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+# ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
+from tools.build_pyinstaller_hiddenimports import (
+    EXTERNAL_PLUGIN_HIDDENIMPORTS,
+    EXTERNAL_PLUGIN_HOST_HIDDENIMPORTS,
+    OFFICIAL_EXTERNAL_PLUGIN_HIDDENIMPORTS,
+)
+
+
+def test_build_pyinstaller_hiddenimports_include_external_plugin_host_api() -> None:
+    expected_modules = {
+        "bitcoin_safe.plugin_framework.external_plugin_resources",
+        "bitcoin_safe.plugin_framework.paid_plugin_client",
+        "bitcoin_safe.plugin_framework.plugin_bundle",
+        "bitcoin_safe.plugin_framework.plugin_conditions",
+        "bitcoin_safe.plugin_framework.plugin_server",
+        "bitcoin_safe.plugin_framework.subscription_manager",
+        "bitcoin_safe.plugin_framework.subscription_price_lookup",
+    }
+
+    assert expected_modules.issubset(EXTERNAL_PLUGIN_HOST_HIDDENIMPORTS)
+    assert len(EXTERNAL_PLUGIN_HOST_HIDDENIMPORTS) == len(set(EXTERNAL_PLUGIN_HOST_HIDDENIMPORTS))
+
+
+def test_build_pyinstaller_hiddenimports_include_official_external_plugin_modules() -> None:
+    expected_modules = {
+        "bitcoin_safe.gui.qt.amount_currency_selector",
+        "bitcoin_safe.gui.qt.currency_converter",
+        "bitcoin_safe.gui.qt.ui_tx.spinbox",
+        "bitcoin_safe.gui.qt.category_manager.category_core",
+        "bitcoin_safe.gui.qt.category_manager.category_list",
+        "bitcoin_safe.gui.qt.category_manager.category_menu",
+    }
+
+    assert expected_modules.issubset(OFFICIAL_EXTERNAL_PLUGIN_HIDDENIMPORTS)
+    assert len(OFFICIAL_EXTERNAL_PLUGIN_HIDDENIMPORTS) == len(set(OFFICIAL_EXTERNAL_PLUGIN_HIDDENIMPORTS))
+
+
+def test_build_pyinstaller_hiddenimports_merge_host_and_official_modules() -> None:
+    assert set(EXTERNAL_PLUGIN_HOST_HIDDENIMPORTS).issubset(EXTERNAL_PLUGIN_HIDDENIMPORTS)
+    assert set(OFFICIAL_EXTERNAL_PLUGIN_HIDDENIMPORTS).issubset(EXTERNAL_PLUGIN_HIDDENIMPORTS)
+    assert len(EXTERNAL_PLUGIN_HIDDENIMPORTS) == len(set(EXTERNAL_PLUGIN_HIDDENIMPORTS))

--- a/tools/build-mac/osx.spec
+++ b/tools/build-mac/osx.spec
@@ -2,6 +2,7 @@
 
 from pathlib import Path
 import platform
+import runpy
 import site
 from PyInstaller.utils.hooks import collect_data_files, collect_submodules, collect_dynamic_libs, copy_metadata
 from PyInstaller.building.api import COLLECT, EXE, PYZ
@@ -33,6 +34,9 @@ PACKAGE_NAME='Bitcoin Safe.app'
 PYPKG='bitcoin_safe'
 PROJECT_ROOT = os.path.abspath(".")
 ICONS_FILE=f"{PROJECT_ROOT}/tools/resources/icon.icns"
+EXTERNAL_PLUGIN_HIDDENIMPORTS = runpy.run_path(
+    f"{PROJECT_ROOT}/tools/build_pyinstaller_hiddenimports.py"
+)["EXTERNAL_PLUGIN_HIDDENIMPORTS"]
 
 
 VERSION = os.environ.get("BITCOIN_SAFE_VERSION")
@@ -45,6 +49,9 @@ block_cipher = None
 hiddenimports = [] 
 hiddenimports += collect_submodules('pkg_resources')  # workaround for https://github.com/pypa/setuptools/issues/1963
 hiddenimports += collect_submodules('hwilib') # otherwise hwilib doesnt get packaged
+# External plugins are imported dynamically from the user config dir, so their
+# imports of plugin-host and packaged-app modules must be bundled explicitly.
+hiddenimports += list(EXTERNAL_PLUGIN_HIDDENIMPORTS)
 
 packages_with_dlls = [ 'bdkpython', 'nostr_sdk', 'pyzbar', 'pygame', "numpy.libs", "cv2"]
 

--- a/tools/build-wine/deterministic.spec
+++ b/tools/build-wine/deterministic.spec
@@ -1,6 +1,7 @@
 # -*- mode: python -*-
 
 from pathlib import Path
+import runpy
 import site
 from PyInstaller.utils.hooks import collect_data_files, collect_submodules, collect_dynamic_libs, copy_metadata
 from PyInstaller.building.api import COLLECT, EXE, PYZ
@@ -12,6 +13,9 @@ import certifi
 PYPKG="bitcoin_safe"
 PROJECT_ROOT = "C:/bitcoin_safe"
 ICONS_FILE=f"{PROJECT_ROOT}/tools/resources/icon.ico"
+EXTERNAL_PLUGIN_HIDDENIMPORTS = runpy.run_path(
+    f"{PROJECT_ROOT}/tools/build_pyinstaller_hiddenimports.py"
+)["EXTERNAL_PLUGIN_HIDDENIMPORTS"]
 
 cmdline_name = os.environ.get("bitcoin_safe_CMDLINE_NAME")
 if not cmdline_name:
@@ -21,6 +25,9 @@ if not cmdline_name:
 hiddenimports = []
 hiddenimports += collect_submodules('pkg_resources')  # workaround for https://github.com/pypa/setuptools/issues/1963
 hiddenimports += collect_submodules('hwilib') # otherwise hwilib doesnt get packaged
+# External plugins are imported dynamically from the user config dir, so their
+# imports of plugin-host and packaged-app modules must be bundled explicitly.
+hiddenimports += list(EXTERNAL_PLUGIN_HIDDENIMPORTS)
 
 
 packages_with_dlls = [ 'bdkpython', 'nostr_sdk', 'pyzbar', 'pygame', "numpy.libs", "cv2"]

--- a/tools/build_pyinstaller_hiddenimports.py
+++ b/tools/build_pyinstaller_hiddenimports.py
@@ -1,0 +1,84 @@
+# Current official remote plugins import these modules from the packaged app.
+# Bitcoin Safe
+# Copyright (C) 2026 Andreas Griffin
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of version 3 of the GNU General Public License as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see https://www.gnu.org/licenses/gpl-3.0.html
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+# BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+# ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+# Listing them here keeps the macOS app and Windows exe builds in sync.
+
+
+"""PyInstaller hidden imports needed by packaged desktop builds.
+
+External plugins are loaded dynamically from the user config directory, so
+PyInstaller cannot discover every host-side module they import while analyzing
+the main application entrypoint.
+"""
+
+EXTERNAL_PLUGIN_HOST_HIDDENIMPORTS: tuple[str, ...] = (
+    "bitcoin_safe.plugin_framework.external_plugin_resources",
+    "bitcoin_safe.plugin_framework.paid_plugin_client",
+    "bitcoin_safe.plugin_framework.plugin_bundle",
+    "bitcoin_safe.plugin_framework.plugin_conditions",
+    "bitcoin_safe.plugin_framework.plugin_server",
+    "bitcoin_safe.plugin_framework.subscription_manager",
+    "bitcoin_safe.plugin_framework.subscription_price_lookup",
+)
+
+OFFICIAL_EXTERNAL_PLUGIN_HIDDENIMPORTS: tuple[str, ...] = (
+    "bitcoin_safe.category_info",
+    "bitcoin_safe.config",
+    "bitcoin_safe.constants",
+    "bitcoin_safe.fx",
+    "bitcoin_safe.gui.qt.amount_currency_selector",
+    "bitcoin_safe.gui.qt.category_manager.category_core",
+    "bitcoin_safe.gui.qt.category_manager.category_list",
+    "bitcoin_safe.gui.qt.category_manager.category_menu",
+    "bitcoin_safe.gui.qt.currency_combobox",
+    "bitcoin_safe.gui.qt.currency_converter",
+    "bitcoin_safe.gui.qt.gpg_verify",
+    "bitcoin_safe.gui.qt.my_treeview",
+    "bitcoin_safe.gui.qt.notification_bar",
+    "bitcoin_safe.gui.qt.sidebar.sidebar_tree",
+    "bitcoin_safe.gui.qt.sign_message",
+    "bitcoin_safe.gui.qt.ui_tx.base_column",
+    "bitcoin_safe.gui.qt.ui_tx.spinbox",
+    "bitcoin_safe.gui.qt.util",
+    "bitcoin_safe.gui.qt.wrappers",
+    "bitcoin_safe.i18n",
+    "bitcoin_safe.pythonbdk_types",
+    "bitcoin_safe.signature_manager",
+    "bitcoin_safe.signals",
+    "bitcoin_safe.tx",
+    "bitcoin_safe.util",
+    "bitcoin_safe.wallet",
+)
+
+EXTERNAL_PLUGIN_HIDDENIMPORTS: tuple[str, ...] = tuple(
+    dict.fromkeys(
+        (
+            *EXTERNAL_PLUGIN_HOST_HIDDENIMPORTS,
+            *OFFICIAL_EXTERNAL_PLUGIN_HIDDENIMPORTS,
+        )
+    )
+)


### PR DESCRIPTION


### What Changed
- **New module:** `tools/build_pyinstaller_hiddenimports.py` – centralized configuration for hidden imports with two categories:
  - External plugin host API modules (7 modules in plugin framework)
  - Official external plugin dependencies (24 UI and utility modules)
  
- **Updated build specs:** Both macOS (`osx.spec`) and Windows Wine (`deterministic.spec`) builders now load and include these hidden imports during packaging

- **Test file:** New pytest module validates that all expected modules are properly included and deduplicated
 

## Required

- `pre-commit install` before any commit. If pre-commit wasn't run for all commits, you can squash all commits   `git reset --soft $(git merge-base main HEAD) && git commit -m "squash"` and ensure the squashed commit is properly formatted
- All commits must be signed. If some are not, you can squash all commits   `git reset --soft $(git merge-base main HEAD) && git commit -m "squash"` and ensure the squashed commit is signed
- [ ] UI/Design/Menu changes **were** tested on _macOS_, because _macOS_ creates endless problems.  Optionally attach a screenshot.
 
## Optional

- [ ] Update all translations
- [ ] Appropriate pytests were added
- [ ] Documentation is updated
- [ ] If this PR affects builds or install artifacts, set the `Build-Relevant` label to trigger build workflows
- [ ] If this PR affects reproducible build outputs, set the `Reproducibility-Relevant` label to trigger the checksum comparison workflow
- [ ] Instruct AI 
```
create a concise summary (bullet points, no stats) for this pr and make a good title
```
