### PR TITLE
Can delete plugin, even when failed loading

### DIFF
--- a/bitcoin_safe/plugin_framework/plugin_list_widget.py
+++ b/bitcoin_safe/plugin_framework/plugin_list_widget.py
@@ -757,6 +757,7 @@ class SourceCatalogItemWidget(BasePluginWidget):
             parent=parent,
         )
         self.install_button = self.add_spinning_detail_button()
+        self.delete_button = self.add_spinning_management_button()
         self.updateUi()
 
     def updateUi(self) -> None:
@@ -776,6 +777,13 @@ class SourceCatalogItemWidget(BasePluginWidget):
             callback=self.item.trigger_install,
             visible=self.item.show_install_button(),
             enable=True,
+        )
+        self._set_button_action(
+            button=self.delete_button,
+            text=self.tr("Delete Plugin"),
+            callback=self.item.request_delete,
+            visible=self.item.can_delete_plugin(),
+            enable=self.item.can_delete_plugin(),
         )
         self._sync_section_visibility()
 

--- a/bitcoin_safe/plugin_framework/plugin_manager.py
+++ b/bitcoin_safe/plugin_framework/plugin_manager.py
@@ -790,6 +790,7 @@ class PluginManager(BaseSaveableClass):
         for entry in entries:
             item = SourceCatalogItem(entry=entry, parent=self.parent)
             item.signal_install_requested.connect(self.install_source_plugin)
+            item.signal_delete_requested.connect(self.delete_installed_source_plugin_by_bundle_id)
             self.source_catalog_items.append(item)
 
     def get_instance(self, cls: type[T], clients: list[PluginClient] | None = None) -> T | None:
@@ -1422,14 +1423,12 @@ class PluginManager(BaseSaveableClass):
         except ExternalPluginError as exc:
             Message(str(exc), type=MessageType.Error, parent=self.parent or self.widget)
 
+    def delete_installed_source_plugin_by_bundle_id(self, bundle_id: str) -> None:
+        entry = self.available_source_plugins_by_bundle_id.get(bundle_id)
+        plugin_name = entry.display_name if entry else bundle_id
+        self._delete_installed_source_plugin(bundle_id=bundle_id, plugin_name=plugin_name)
+
     def delete_installed_source_plugin(self, client: PluginClient) -> None:
-        if client.enabled:
-            Message(
-                self.widget.tr("Disable the plugin before deleting it."),
-                type=MessageType.Error,
-                parent=self.parent or self.widget,
-            )
-            return
         if client.plugin_bundle_id is None:
             Message(
                 self.widget.tr("This plugin cannot be deleted."),
@@ -1437,8 +1436,24 @@ class PluginManager(BaseSaveableClass):
                 parent=self.parent or self.widget,
             )
             return
+        self._delete_installed_source_plugin(bundle_id=client.plugin_bundle_id, plugin_name=client.title)
+
+    def _delete_installed_source_plugin(self, bundle_id: str, plugin_name: str) -> None:
+        removed_clients = [
+            existing_client
+            for existing_client in self.clients
+            if existing_client.plugin_source == PluginClientSource.EXTERNAL
+            and existing_client.plugin_bundle_id == bundle_id
+        ]
+        for removed_client in removed_clients:
+            if not removed_client.enabled:
+                continue
+            try:
+                removed_client.set_enabled(False)
+            except Exception:
+                logger.exception("Could not disable plugin %s before deletion.", removed_client.plugin_id)
         if not question_dialog(
-            text=self.widget.tr("Delete installed plugin {plugin}?").format(plugin=client.title),
+            text=self.widget.tr("Delete installed plugin {plugin}?").format(plugin=plugin_name),
             title=self.widget.tr("Delete Installed Plugin"),
             true_button=self.widget.tr("Delete"),
             false_button=self.widget.tr("Cancel"),
@@ -1446,14 +1461,7 @@ class PluginManager(BaseSaveableClass):
             return
 
         try:
-            bundle_id = client.plugin_bundle_id
             self.external_registry.remove_installed_plugin(bundle_id)
-            removed_clients = [
-                existing_client
-                for existing_client in self.clients
-                if existing_client.plugin_source == PluginClientSource.EXTERNAL
-                and existing_client.plugin_bundle_id == bundle_id
-            ]
             self.serialized_client_dumps = self._merge_serialized_client_payloads(
                 [
                     *self.serialized_client_dumps,
@@ -1469,7 +1477,7 @@ class PluginManager(BaseSaveableClass):
             self._reconnect_client_signals()
             runtime_changed = self._refresh_external_registry_state()
             self._refresh_after_registry_change(runtime_changed)
-            logger.info("Deleted plugin %s.", client.title)
+            logger.info("Deleted plugin %s.", plugin_name)
         except ExternalPluginError as exc:
             Message(str(exc), type=MessageType.Error, parent=self.parent or self.widget)
 

--- a/bitcoin_safe/plugin_framework/plugin_source_widget.py
+++ b/bitcoin_safe/plugin_framework/plugin_source_widget.py
@@ -339,6 +339,7 @@ class SourceCatalogItem(QObject):
         SignalProtocol[[ExternalPluginCatalogEntry]],
         pyqtSignal(ExternalPluginCatalogEntry),
     )
+    signal_delete_requested = cast(SignalProtocol[[str]], pyqtSignal(str))
     signal_request_enabled = cast(SignalProtocol[[bool]], pyqtSignal(bool))
     signal_enabled_changed = cast(SignalProtocol[[bool]], pyqtSignal(bool))
     signal_needs_persist = cast(SignalProtocol[[]], pyqtSignal())
@@ -393,6 +394,9 @@ class SourceCatalogItem(QObject):
     def show_install_button(self) -> bool:
         return self.entry.installed_version is None or self.entry.update_available
 
+    def can_delete_plugin(self) -> bool:
+        return self.entry.installed_version is not None
+
     def _available_update_target_text(self) -> str:
         return format_version_with_hash(
             self,
@@ -402,6 +406,10 @@ class SourceCatalogItem(QObject):
 
     def trigger_install(self) -> None:
         self.signal_install_requested.emit(self.entry)
+
+    def request_delete(self) -> None:
+        if self.can_delete_plugin():
+            self.signal_delete_requested.emit(self.entry.bundle_id)
 
     def create_plugin_widget(
         self,

--- a/tests/non_gui/test_external_plugins.py
+++ b/tests/non_gui/test_external_plugins.py
@@ -3489,6 +3489,124 @@ def test_delete_installed_source_plugin_keeps_serialized_payload_and_clears_perm
         manager.close()
 
 
+def test_enabled_external_plugin_widget_hides_delete_button(qapp: QApplication) -> None:
+    del qapp
+
+    client = _LoadTrackingPluginClient(enabled=True)
+    client.set_plugin_identity(
+        plugin_source=PluginClientSource.EXTERNAL,
+        plugin_bundle_id="test-plugin",
+    )
+    widget = client.create_plugin_widget(parent=None)
+
+    try:
+        assert not client.can_delete_plugin()
+        assert widget.delete_button.isHidden()
+    finally:
+        widget.close()
+        client.close()
+
+
+def test_delete_installed_source_plugin_by_bundle_id_preserves_pending_payload(
+    qapp: QApplication, tmp_path: Path, monkeypatch
+) -> None:
+    del qapp
+
+    monkeypatch.setattr(
+        PluginManager,
+        "_refresh_external_state",
+        classmethod(lambda cls, context, external_registry: {}),
+    )
+    monkeypatch.setattr("bitcoin_safe.plugin_framework.plugin_manager.question_dialog", lambda **kwargs: True)
+
+    client = _DisplayMetadataPluginClient()
+    client.set_plugin_identity(
+        plugin_source=PluginClientSource.EXTERNAL,
+        plugin_bundle_id="broken-plugin",
+    )
+    payload = _serialized_client_payload(client)
+    client.close()
+
+    manager = PluginManager(
+        clients=[],
+        serialized_client_dumps=[payload],
+        parent=None,
+        **_plugin_manager_init_kwargs(tmp_path),
+    )
+
+    removed_bundle_ids: list[str] = []
+
+    try:
+        monkeypatch.setattr(
+            manager.external_registry,
+            "remove_installed_plugin",
+            lambda bundle_id: removed_bundle_ids.append(bundle_id),
+        )
+        monkeypatch.setattr(manager, "_refresh_external_registry_state", lambda: False)
+        monkeypatch.setattr(manager, "_refresh_after_registry_change", lambda runtime_changed: None)
+        manager.available_source_plugins_by_bundle_id = {
+            "broken-plugin": ExternalPluginCatalogEntry(
+                source_id="source-id",
+                source_display_name="Source",
+                bundle_id="broken-plugin",
+                version="1.0.0",
+                display_name="Broken Plugin",
+                description="",
+                provider="Tests",
+                entrypoint="plugins/broken",
+                plugin_api_version="1",
+                app_version_specifier=">=0",
+                folder_hash="hash",
+                release_ref="main",
+                installed_version="1.0.0",
+            )
+        }
+
+        manager.delete_installed_source_plugin_by_bundle_id("broken-plugin")
+
+        assert removed_bundle_ids == ["broken-plugin"]
+        assert manager.serialized_client_dumps == [payload]
+    finally:
+        manager.close()
+
+
+def test_source_catalog_item_allows_delete_for_installed_plugin(qapp: QApplication) -> None:
+    del qapp
+    item = SourceCatalogItem(
+        entry=ExternalPluginCatalogEntry(
+            source_id="source-id",
+            source_display_name="Source",
+            bundle_id="broken-plugin",
+            version="1.0.0",
+            display_name="Broken Plugin",
+            description="",
+            provider="Tests",
+            entrypoint="plugins/broken",
+            plugin_api_version="1",
+            app_version_specifier=">=0",
+            folder_hash="hash",
+            release_ref="main",
+            installed_version="1.0.0",
+        ),
+        parent=None,
+    )
+    deleted_bundle_ids: list[str] = []
+    item.signal_delete_requested.connect(deleted_bundle_ids.append)
+
+    widget = item.create_plugin_widget(parent=None)
+
+    try:
+        assert item.can_delete_plugin()
+        assert not widget.delete_button.isHidden()
+        assert widget.delete_button.isEnabled()
+
+        item.request_delete()
+
+        assert deleted_bundle_ids == ["broken-plugin"]
+    finally:
+        widget.close()
+
+
 def test_plugin_manager_widget_sidebar_rebuild_keeps_other_enabled_plugins_visible(
     qapp: QApplication,
 ) -> None:


### PR DESCRIPTION
## Required

- `pre-commit install` before any commit. If pre-commit wasn't run for all commits, you can squash all commits   `git reset --soft $(git merge-base main HEAD) && git commit -m "squash"` and ensure the squashed commit is properly formatted
- All commits must be signed. If some are not, you can squash all commits   `git reset --soft $(git merge-base main HEAD) && git commit -m "squash"` and ensure the squashed commit is signed
- [ ] UI/Design/Menu changes **were** tested on _macOS_, because _macOS_ creates endless problems.  Optionally attach a screenshot.
 
## Optional

- [ ] Update all translations
- [ ] Appropriate pytests were added
- [ ] Documentation is updated
- [ ] If this PR affects builds or install artifacts, set the `Build-Relevant` label to trigger build workflows
- [ ] If this PR affects reproducible build outputs, set the `Reproducibility-Relevant` label to trigger the checksum comparison workflow
- [ ] Instruct AI 
```
create a concise summary (bullet points, no stats) for this pr and make a good title
```
