### PR TITLE
Preserve plugin payloads when plugins become unavailable

### DIFF
--- a/bitcoin_safe/plugin_framework/plugin_manager.py
+++ b/bitcoin_safe/plugin_framework/plugin_manager.py
@@ -993,8 +993,29 @@ class PluginManager(BaseSaveableClass):
             client.updateUi()
         self.widget.updateUi()
 
+    def _serialized_existing_client_payloads(self, existing_clients: list[PluginClient]) -> list[str]:
+        return self._merge_serialized_client_payloads(
+            [self._serialize_client_payload(client) for client in existing_clients]
+        )
+
+    def _retain_unrestored_existing_client_payloads(
+        self,
+        serialized_existing_client_payloads: list[str],
+    ) -> None:
+        restored_plugin_ids = {client.plugin_id for client in self.clients}
+        unresolved_payloads: list[str] = []
+        for payload in serialized_existing_client_payloads:
+            identity = self._payload_identity(payload)
+            if identity is not None and identity in restored_plugin_ids:
+                continue
+            unresolved_payloads.append(payload)
+        self.serialized_client_dumps = self._merge_serialized_client_payloads(
+            [*self.serialized_client_dumps, *unresolved_payloads]
+        )
+
     def _restore_or_create_clients(self, descriptor: bdk.Descriptor) -> None:
         existing_clients = self.clients.copy()
+        serialized_existing_client_payloads = self._serialized_existing_client_payloads(existing_clients)
         self.clients.clear()
         candidate_classes = {
             cls
@@ -1020,6 +1041,7 @@ class PluginManager(BaseSaveableClass):
                 self._register_client(restored_pending_client)
             elif discovered_client := discovered_clients_by_class.get(cls):
                 self._register_client(discovered_client)
+        self._retain_unrestored_existing_client_payloads(serialized_existing_client_payloads)
 
     def create_and_connect_clients(
         self,

--- a/tests/non_gui/test_external_plugins.py
+++ b/tests/non_gui/test_external_plugins.py
@@ -3440,6 +3440,82 @@ def test_plugin_manager_keeps_payload_pending_when_client_from_dump_fails_then_r
         manager.close()
 
 
+def test_plugin_manager_preserves_live_client_payload_when_runtime_client_becomes_unavailable(
+    qapp: QApplication, tmp_path: Path, monkeypatch
+) -> None:
+    del qapp
+    monkeypatch.setattr(
+        PluginManager,
+        "_refresh_external_state",
+        classmethod(lambda cls, context, external_registry: {}),
+    )
+
+    client = _DisplayMetadataPluginClient()
+    client.set_plugin_identity(
+        plugin_source=PluginClientSource.EXTERNAL,
+        plugin_bundle_id="test-plugin",
+    )
+    manager = PluginManager(
+        clients=[client],
+        parent=None,
+        **_plugin_manager_init_kwargs(tmp_path),
+    )
+
+    try:
+        monkeypatch.setattr(manager, "_all_client_classes", lambda: [])
+
+        manager.create_and_connect_clients(
+            descriptor=_test_descriptor(),
+            wallet_id="wallet-id",
+            category_core=SimpleNamespace(),
+        )
+
+        dumped = manager.dump()
+
+        assert manager.clients == []
+        assert len(manager.serialized_client_dumps) == 1
+        assert PluginManager._payload_identity(manager.serialized_client_dumps[0]) == client.plugin_id
+        assert dumped["serialized_client_dumps"] == manager.serialized_client_dumps
+    finally:
+        manager.close()
+
+
+def test_plugin_manager_discards_snapshot_payload_when_live_client_survives_rebuild(
+    qapp: QApplication, tmp_path: Path, monkeypatch
+) -> None:
+    del qapp
+    monkeypatch.setattr(
+        PluginManager,
+        "_refresh_external_state",
+        classmethod(lambda cls, context, external_registry: {}),
+    )
+
+    client = _DisplayMetadataPluginClient()
+    client.set_plugin_identity(
+        plugin_source=PluginClientSource.EXTERNAL,
+        plugin_bundle_id="test-plugin",
+    )
+    manager = PluginManager(
+        clients=[client],
+        parent=None,
+        **_plugin_manager_init_kwargs(tmp_path),
+    )
+
+    try:
+        monkeypatch.setattr(manager, "_all_client_classes", lambda: [client.__class__])
+
+        manager.create_and_connect_clients(
+            descriptor=_test_descriptor(),
+            wallet_id="wallet-id",
+            category_core=SimpleNamespace(),
+        )
+
+        assert manager.clients == [client]
+        assert manager.serialized_client_dumps == []
+    finally:
+        manager.close()
+
+
 def test_delete_installed_source_plugin_keeps_serialized_payload_and_clears_permissions(
     qapp: QApplication, tmp_path: Path, monkeypatch
 ) -> None:


### PR DESCRIPTION
## Required

- `pre-commit install` before any commit. If pre-commit wasn't run for all commits, you can squash all commits   `git reset --soft $(git merge-base main HEAD) && git commit -m "squash"` and ensure the squashed commit is properly formatted
- All commits must be signed. If some are not, you can squash all commits   `git reset --soft $(git merge-base main HEAD) && git commit -m "squash"` and ensure the squashed commit is signed
- [ ] UI/Design/Menu changes **were** tested on _macOS_, because _macOS_ creates endless problems.  Optionally attach a screenshot.
 
## Optional

- [ ] Update all translations
- [ ] Appropriate pytests were added
- [ ] Documentation is updated
- [ ] If this PR affects builds or install artifacts, set the `Build-Relevant` label to trigger build workflows
- [ ] If this PR affects reproducible build outputs, set the `Reproducibility-Relevant` label to trigger the checksum comparison workflow
- [ ] Instruct AI 
```
create a concise summary (bullet points, no stats) for this pr and make a good title
```
