### PR TITLE
Fix duplicate send test prompt on wallet reopen

### DIFF
--- a/bitcoin_safe/gui/qt/main.py
+++ b/bitcoin_safe/gui/qt/main.py
@@ -2785,9 +2785,6 @@ class MainWindow(UnlockableMainWindow):
 
         self.tab_wallets.root.addChildNode(qt_wallet.tabs, focus=focus)
 
-        if qt_wallet.tutorial_index is not None:
-            qt_wallet.wizard.set_current_index(qt_wallet.tutorial_index)
-
         if qt_wallet.wizard.should_be_visible:
             qt_wallet.wizard.set_visibilities()
             qt_wallet.wizard.node.select()

--- a/bitcoin_safe/gui/qt/wizard/wizard.py
+++ b/bitcoin_safe/gui/qt/wizard/wizard.py
@@ -616,6 +616,11 @@ class Wizard(WizardBase):
         number = ceil(n / m)
         return list(TutorialStep.send_test_steps()[:number])
 
+    def get_send_test_step_label(self, test_number: int) -> str:
+        """Return the progress-bar label for a send test."""
+        step = self.get_send_tests_steps()[test_number]
+        return self.step_container.step_bar.labels[self.index_of_step(step)]
+
     def get_send_test_labels(self, mn_tuple: tuple[int, int] | None = None) -> list[str]:
         """Get send test labels."""
         m, n = mn_tuple if mn_tuple is not None else self.qtwalletbase.get_mn_tuple()

--- a/bitcoin_safe/gui/qt/wizard/wizard_step_send.py
+++ b/bitcoin_safe/gui/qt/wizard/wizard_step_send.py
@@ -129,13 +129,22 @@ class SendTest(BaseTab):
                 return
 
         txos = self.refs.qt_wallet.wallet.get_all_txos_dict(include_not_mine=False).values()
-        spend_txos = [txo for txo in txos if txo.is_spent_by_txid]
-        if spend_txos and len(spend_txos) >= self.test_number + 1:
+        outgoing_txids = {txo.is_spent_by_txid for txo in txos if txo.is_spent_by_txid}
+        if len(outgoing_txids) >= self.test_number + 1:
+            wizard = self.wizard_parent()
+            send_test_name = (
+                wizard.get_send_test_step_label(self.test_number)
+                if wizard
+                else self._card_title(self.test_number)
+            )
             if question_dialog(
                 text=self.tr(
-                    "You made {n} outgoing transactions already. Would you like to skip this spend test?"
-                ).format(n=len(spend_txos)),
-                title=self.tr("Skip spend test?"),
+                    "You made {n} outgoing transactions already. Would you like to skip {send_test_name}?"
+                ).format(
+                    n=len(outgoing_txids),
+                    send_test_name=send_test_name,
+                ),
+                title=self.tr("Skip {send_test_name}?").format(send_test_name=send_test_name),
                 true_button=QMessageBox.StandardButton.Yes,
                 false_button=QMessageBox.StandardButton.No,
             ):

--- a/tests/gui/qt/test_wizard_send_test_routing.py
+++ b/tests/gui/qt/test_wizard_send_test_routing.py
@@ -29,6 +29,7 @@
 
 from __future__ import annotations
 
+from contextlib import nullcontext
 from types import SimpleNamespace
 from unittest.mock import Mock
 
@@ -39,6 +40,7 @@ from PyQt6.QtCore import QObject, Qt, pyqtSignal
 from PyQt6.QtWidgets import QDialogButtonBox, QPushButton, QVBoxLayout, QWidget
 
 from bitcoin_safe.gui.qt.card_base import CardExpansionMode, CardList
+from bitcoin_safe.gui.qt.main import MainWindow
 from bitcoin_safe.gui.qt.send_test_schedule import (
     build_send_test_fingerprint_groups,
     build_send_test_signer_groups,
@@ -514,6 +516,189 @@ def test_send_test_callback_prefers_existing_tutorial_tx_over_skip_prompt(
 
     wizard.on_send_test_step_activated.assert_called_once_with(0)
     question_mock.assert_not_called()
+
+
+def test_add_qt_wallet_does_not_restore_tutorial_step_twice(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    wizard = SimpleNamespace(
+        should_be_visible=True,
+        set_current_index=Mock(),
+        set_visibilities=Mock(),
+        node=SimpleNamespace(select=Mock()),
+    )
+    monkeypatch.setattr("bitcoin_safe.gui.qt.main.Wizard", Mock(return_value=wizard))
+    monkeypatch.setattr("bitcoin_safe.gui.qt.main.LoadingWalletTab", Mock(return_value=nullcontext()))
+
+    wallet_id = "wallet"
+    wallet_signal = SimpleNamespace(connect=Mock())
+    qt_wallet = SimpleNamespace(
+        wallet=SimpleNamespace(id=wallet_id),
+        tutorial_index=4,
+        tabs=SimpleNamespace(setIcon=Mock(), setTitle=Mock()),
+        wallet_signals=SimpleNamespace(updated=SimpleNamespace(emit=Mock())),
+        signal_request_open_network_settings=wallet_signal,
+        signal_progress_info=wallet_signal,
+        signal_refresh_sync_status=wallet_signal,
+    )
+    main_window = SimpleNamespace(
+        qt_wallets={},
+        tr=lambda text: text,
+        tab_wallets=SimpleNamespace(root=SimpleNamespace(addChildNode=Mock())),
+        _remove_create_screens=Mock(),
+        language_chooser=SimpleNamespace(add_signal_language_switch=Mock()),
+        signals=SimpleNamespace(language_switch=wallet_signal),
+        wallet_functions=SimpleNamespace(
+            wallet_signals={wallet_id: SimpleNamespace(show_address=wallet_signal)}
+        ),
+        signal_tracker=SimpleNamespace(connect=Mock()),
+        show_address=Mock(),
+        open_network_settings=Mock(),
+        refresh_global_network_map=Mock(),
+        p2p_listening_update_lists=Mock(),
+        update_all_history_initial_sync_widgets=Mock(),
+        refresh_plugin_notification_bars=Mock(),
+    )
+
+    result = MainWindow.add_qt_wallet(main_window, qt_wallet, focus=False)
+
+    assert result is qt_wallet
+    wizard.set_current_index.assert_not_called()
+    wizard.set_visibilities.assert_called_once_with()
+
+
+def test_send_test_callback_counts_distinct_outgoing_transactions(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    question_mock = Mock(return_value=True)
+    monkeypatch.setattr("bitcoin_safe.gui.qt.wizard.wizard_step_send.question_dialog", question_mock)
+
+    wizard = SimpleNamespace(
+        get_send_test_txid=Mock(return_value=None),
+        on_send_test_step_activated=Mock(),
+        get_send_test_step_label=Mock(return_value="Self-Send test 2"),
+    )
+    qt_wallet = SimpleNamespace(
+        wallet=SimpleNamespace(
+            client=None,
+            get_all_txos_dict=Mock(
+                return_value={
+                    "first": SimpleNamespace(is_spent_by_txid="outgoing-tx"),
+                    "second": SimpleNamespace(is_spent_by_txid="outgoing-tx"),
+                }
+            ),
+        )
+    )
+    go_to_next_index = Mock()
+    send_test = SimpleNamespace(
+        refs=SimpleNamespace(qt_wallet=qt_wallet, go_to_next_index=go_to_next_index),
+        test_number=1,
+        set_visibilities=Mock(),
+        wizard_parent=lambda: wizard,
+        tr=lambda text: text,
+    )
+
+    SendTest._callback(send_test)
+
+    question_mock.assert_not_called()
+    go_to_next_index.assert_not_called()
+    wizard.on_send_test_step_activated.assert_called_once_with(1)
+
+
+def test_second_send_test_can_be_skipped_after_two_outgoing_transactions(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    question_mock = Mock(return_value=True)
+    monkeypatch.setattr("bitcoin_safe.gui.qt.wizard.wizard_step_send.question_dialog", question_mock)
+
+    wizard = SimpleNamespace(
+        get_send_test_txid=Mock(return_value=None),
+        on_send_test_step_activated=Mock(),
+        get_send_test_step_label=Mock(return_value="Self-Send test 2"),
+    )
+    qt_wallet = SimpleNamespace(
+        wallet=SimpleNamespace(
+            client=None,
+            get_all_txos_dict=Mock(
+                return_value={
+                    "first": SimpleNamespace(is_spent_by_txid="outgoing-tx-1"),
+                    "second": SimpleNamespace(is_spent_by_txid="outgoing-tx-2"),
+                }
+            ),
+        )
+    )
+    go_to_next_index = Mock()
+    send_test = SimpleNamespace(
+        refs=SimpleNamespace(qt_wallet=qt_wallet, go_to_next_index=go_to_next_index),
+        test_number=1,
+        set_visibilities=Mock(),
+        wizard_parent=lambda: wizard,
+        tr=lambda text: text,
+    )
+
+    SendTest._callback(send_test)
+
+    question_mock.assert_called_once()
+    assert question_mock.call_args.kwargs["text"] == (
+        "You made 2 outgoing transactions already. Would you like to skip Self-Send test 2?"
+    )
+    assert question_mock.call_args.kwargs["title"] == "Skip Self-Send test 2?"
+    go_to_next_index.assert_called_once_with()
+    wizard.on_send_test_step_activated.assert_not_called()
+
+
+def test_single_send_test_skip_prompt_uses_unnumbered_progress_label(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    question_mock = Mock(return_value=True)
+    monkeypatch.setattr("bitcoin_safe.gui.qt.wizard.wizard_step_send.question_dialog", question_mock)
+
+    wizard = SimpleNamespace(
+        get_send_test_txid=Mock(return_value=None),
+        on_send_test_step_activated=Mock(),
+        get_send_test_step_label=Mock(return_value="Self-Send test"),
+    )
+    qt_wallet = SimpleNamespace(
+        wallet=SimpleNamespace(
+            client=None,
+            get_all_txos_dict=Mock(
+                return_value={
+                    "first": SimpleNamespace(is_spent_by_txid="outgoing-tx-1"),
+                    "second": SimpleNamespace(is_spent_by_txid="outgoing-tx-2"),
+                }
+            ),
+        )
+    )
+    send_test = SimpleNamespace(
+        refs=SimpleNamespace(qt_wallet=qt_wallet, go_to_next_index=Mock()),
+        test_number=0,
+        set_visibilities=Mock(),
+        wizard_parent=lambda: wizard,
+        tr=lambda text: text,
+    )
+
+    SendTest._callback(send_test)
+
+    assert question_mock.call_args.kwargs["text"] == (
+        "You made 2 outgoing transactions already. Would you like to skip Self-Send test?"
+    )
+    assert question_mock.call_args.kwargs["title"] == "Skip Self-Send test?"
+
+
+@pytest.mark.parametrize(
+    ("mn_tuple", "expected_send_tests"),
+    [
+        ((1, 1), 1),
+        ((2, 3), 2),
+        ((1, 5), 5),
+    ],
+)
+def test_send_test_count_covers_all_multisig_signers(
+    mn_tuple: tuple[int, int], expected_send_tests: int
+) -> None:
+    wizard = SimpleNamespace(qtwalletbase=SimpleNamespace(get_mn_tuple=lambda: mn_tuple))
+
+    assert len(Wizard.get_send_tests_steps(wizard)) == expected_send_tests
 
 
 def test_configure_creator_for_embedded_send_test_swaps_reset_for_previous() -> None:


### PR DESCRIPTION
## Required

- `pre-commit install` before any commit. If pre-commit wasn't run for all commits, you can squash all commits   `git reset --soft $(git merge-base main HEAD) && git commit -m "squash"` and ensure the squashed commit is properly formatted
- All commits must be signed. If some are not, you can squash all commits   `git reset --soft $(git merge-base main HEAD) && git commit -m "squash"` and ensure the squashed commit is signed
- [ ] UI/Design/Menu changes **were** tested on _macOS_, because _macOS_ creates endless problems.  Optionally attach a screenshot.
 
## Optional

- [ ] Update all translations
- [ ] Appropriate pytests were added
- [ ] Documentation is updated
- [ ] If this PR affects builds or install artifacts, set the `Build-Relevant` label to trigger build workflows
- [ ] If this PR affects reproducible build outputs, set the `Reproducibility-Relevant` label to trigger the checksum comparison workflow
- [ ] Instruct AI 
```
create a concise summary (bullet points, no stats) for this pr and make a good title
```
