### PR TITLE
Avoid keystore refresh while editing notes

### DIFF
--- a/bitcoin_safe/gui/qt/keystore_ui.py
+++ b/bitcoin_safe/gui/qt/keystore_ui.py
@@ -458,7 +458,6 @@ class KeyStoreUI(CardBase):
             cast(SignalProtocol[[]], self.edit_key_origin.input_field.textChanged),
             cast(SignalProtocol[[]], self.edit_xpub.input_field.textChanged),
             cast(SignalProtocol[[]], self.edit_seed.input_field.textChanged),
-            cast(SignalProtocol[[]], self.textEdit_description.textChanged),
         ):
             self.signal_tracker.connect(signal, self.signal_ui_changed.emit)
 

--- a/bitcoin_safe/gui/qt/wizard/wizard_step_distribution.py
+++ b/bitcoin_safe/gui/qt/wizard/wizard_step_distribution.py
@@ -103,6 +103,8 @@ class RegisterMultisig(BaseTab):
             read_only_mode=True,
             show_register_button=True,
         )
+        for keystore_ui in self.keystore_uis.getAllTabData().values():
+            keystore_ui.textEdit_description.setReadOnly(True)
         self.keystore_uis.request_show_register_multisig.connect(self._show_register_multisig)
         widget_layout.addWidget(self.keystore_uis)
 

--- a/tests/gui/qt/test_keystore_uis.py
+++ b/tests/gui/qt/test_keystore_uis.py
@@ -34,6 +34,7 @@ from bitcoin_qr_tools.data import SignerInfo
 from bitcoin_safe_lib.async_tools.loop_in_thread import LoopInThread
 from bitcoin_usb.address_types import AddressTypes
 from PyQt6.QtCore import Qt
+from PyQt6.QtTest import QSignalSpy
 from pytestqt.qtbot import QtBot
 
 from bitcoin_safe.gui.qt.keystore_ui import KeyStoreUiState
@@ -102,6 +103,43 @@ def test_keystore_uis_syncs_back_to_protowallet(qtbot: QtBot, loop_in_thread: Lo
 
     assert protowallet.keystores[0] is not None
     assert protowallet.keystores[0].hardware_signer_id == hardware_signer.id
+
+
+def test_description_edit_avoids_signer_refresh_until_explicit_sync(
+    qtbot: QtBot, loop_in_thread: LoopInThread
+) -> None:
+    keystore = create_test_seed_keystores(
+        signers=1,
+        key_origins=[AddressTypes.p2wpkh.key_origin(bdk.Network.REGTEST)],
+        network=bdk.Network.REGTEST,
+    )[0]
+    protowallet = ProtoWallet(
+        wallet_id="wallet",
+        threshold=1,
+        network=bdk.Network.REGTEST,
+        keystores=[keystore],
+        address_type=AddressTypes.p2wpkh,
+    )
+    widget = KeyStoreUIs(
+        get_editable_protowallet=lambda: protowallet,
+        get_address_type=lambda: AddressTypes.p2wpkh,
+        signals_min=SignalsMin(),
+        loop_in_thread=loop_in_thread,
+    )
+    qtbot.addWidget(widget)
+    keystore_ui = next(iter(widget.getAllTabData().values()))
+    ui_change_spy = QSignalSpy(widget.signal_ui_changed)
+    assert not keystore_ui.textEdit_description.isReadOnly()
+
+    keystore_ui.textEdit_description.setPlainText("Signer kept in the office")
+
+    assert len(ui_change_spy) == 0
+    assert keystore.description != "Signer kept in the office"
+    assert "Signer kept in the office" in keystore_ui.header_subtitle.text()
+
+    widget.set_protowallet_from_keystore_ui()
+
+    assert keystore.description == "Signer kept in the office"
 
 
 def test_keystore_uis_expand_only_collapses_other_cards(qtbot: QtBot, loop_in_thread: LoopInThread) -> None:

--- a/tests/gui/qt/test_setup_wallet.py
+++ b/tests/gui/qt/test_setup_wallet.py
@@ -50,6 +50,7 @@ from bitcoin_safe.gui.qt.wizard.wizard import (
     DistributeSeeds,
     PluginListStep,
     ReceiveTest,
+    RegisterMultisig,
     SendTest,
     TutorialStep,
     Wizard,
@@ -235,6 +236,35 @@ def test_distribute_step_update_ui_after_close_does_not_raise(
 
     distribute.close()
     distribute.updateUi()
+
+
+@pytest.mark.marker_qt_1
+def test_registration_step_descriptions_are_read_only(
+    qtbot: QtBot,
+    test_config: TestConfig,
+    backend: str,
+    wallet_name: str = "test_registration_description",
+) -> None:
+    """The registration step displays signer notes without offering to edit them."""
+    del backend
+    with main_window_context(test_config=test_config) as main_window:
+        QTest.qWaitForWindowExposed(main_window, timeout=10000)  # type: ignore
+        qt_wallet = _create_wallet_with_wizard(
+            main_window=main_window,
+            wallet_name=wallet_name,
+            threshold=2,
+            signers=3,
+            tutorial_index=0,
+        )
+        wizard = qt_wallet.wizard
+        assert isinstance(wizard, Wizard)
+        registration = wizard.tab_generators[TutorialStep.register]
+        assert isinstance(registration, RegisterMultisig)
+
+        assert all(
+            keystore_ui.textEdit_description.isReadOnly()
+            for keystore_ui in registration.keystore_uis.getAllTabData().values()
+        )
 
 
 @pytest.mark.marker_qt_1


### PR DESCRIPTION
## Required

- `pre-commit install` before any commit. If pre-commit wasn't run for all commits, you can squash all commits   `git reset --soft $(git merge-base main HEAD) && git commit -m "squash"` and ensure the squashed commit is properly formatted
- All commits must be signed. If some are not, you can squash all commits   `git reset --soft $(git merge-base main HEAD) && git commit -m "squash"` and ensure the squashed commit is signed
- [ ] UI/Design/Menu changes **were** tested on _macOS_, because _macOS_ creates endless problems.  Optionally attach a screenshot.
 
## Optional

- [ ] Update all translations
- [ ] Appropriate pytests were added
- [ ] Documentation is updated
- [ ] If this PR affects builds or install artifacts, set the `Build-Relevant` label to trigger build workflows
- [ ] If this PR affects reproducible build outputs, set the `Reproducibility-Relevant` label to trigger the checksum comparison workflow
- [ ] Instruct AI 
```
create a concise summary (bullet points, no stats) for this pr and make a good title
```
