### PR TITLE
Add subscription portability tooltip

### DIFF
--- a/bitcoin_safe/plugin_framework/plugin_list_widget.py
+++ b/bitcoin_safe/plugin_framework/plugin_list_widget.py
@@ -591,7 +591,10 @@ class PaidPluginWidget(PluginWidget):
         self.subscription_buttons_container = controls.subscription_buttons_container
         self.subscription_buttons_layout = controls.subscription_buttons_layout
         self._plan_option_keys: list[str] = []
-        self.management_title_label = QLabel("", self.management_section)
+        self.management_title_label = IconLabel(parent=self.management_section)
+        self.management_title_label.set_icon_as_help(
+            tooltip=self.tr("This subscription is valid on any computer with this wallet")
+        )
         self.management_buttons_layout.insertWidget(0, self.management_title_label)
 
     def add_subscription_button(self) -> QPushButton:

--- a/bitcoin_safe/plugin_framework/plugin_list_widget.py
+++ b/bitcoin_safe/plugin_framework/plugin_list_widget.py
@@ -52,6 +52,7 @@ from PyQt6.QtWidgets import (
 )
 
 from bitcoin_safe.gui.qt.card_base import CardBase, CardExpansionMode
+from bitcoin_safe.gui.qt.icon_label import IconLabel
 from bitcoin_safe.gui.qt.util import (
     get_neutral_surface_colors,
     should_process_theme_change,
@@ -512,7 +513,7 @@ class PaidPluginControls:
     subscription_layout: QVBoxLayout
     plan_selector_container: QWidget
     plan_selector_layout: QHBoxLayout
-    plan_selector_title_label: QLabel
+    plan_selector_title_label: IconLabel
     plan_selector_combo: QComboBox
     offer_label: QLabel
     subscription_buttons_container: QWidget
@@ -535,7 +536,10 @@ class PaidPluginWidget(PluginWidget):
         plan_selector_layout.setSpacing(8)
         subscription_layout.addWidget(plan_selector_container)
 
-        plan_selector_title_label = QLabel("", plan_selector_container)
+        plan_selector_title_label = IconLabel(parent=plan_selector_container)
+        plan_selector_title_label.set_icon_as_help(
+            tooltip=self.tr("This subscription is valid on any computer with this wallet")
+        )
         plan_selector_layout.addWidget(plan_selector_title_label)
 
         plan_selector_combo = QComboBox(plan_selector_container)

--- a/tests/gui/qt/plugin_framework/test_paid_plugin_client.py
+++ b/tests/gui/qt/plugin_framework/test_paid_plugin_client.py
@@ -407,6 +407,11 @@ def test_plugin_widget_shows_subscription_buttons_when_management_url_known(
     assert not widget.refresh_subscription_button.isHidden()
     assert widget.manage_subscription_button.text() == "Manage"
     assert widget.refresh_subscription_button.text() == "Refresh status"
+    assert widget.management_title_label.textLabel.text() == "Subscription:"
+    assert (
+        widget.management_title_label.toolTip()
+        == "This subscription is valid on any computer with this wallet"
+    )
     assert widget.subscription_section.isHidden()
     assert not widget.management_section.isHidden()
     assert not widget.enable_checkbox.isHidden()

--- a/tests/gui/qt/plugin_framework/test_paid_plugin_client.py
+++ b/tests/gui/qt/plugin_framework/test_paid_plugin_client.py
@@ -480,12 +480,20 @@ def test_plugin_list_widget_shows_btcpay_price_texts(
             lambda: _plan_texts(first_widget) == ["2,00 EUR / month", "20,00 EUR / year"],
             timeout=5_000,
         )
-        assert widget.business_plan_widget.plan_selector_title_label.text() == "Subscription"
+        assert widget.business_plan_widget.plan_selector_title_label.textLabel.text() == "Subscription"
+        assert (
+            widget.business_plan_widget.plan_selector_title_label.toolTip()
+            == "This subscription is valid on any computer with this wallet"
+        )
 
         assert first_widget.start_trial_button.isVisible()
         assert first_widget.start_trial_button.text() == "Start free trial"
         assert first_widget.enable_checkbox.isHidden()
-        assert first_widget.plan_selector_title_label.text() == "Subscription"
+        assert first_widget.plan_selector_title_label.textLabel.text() == "Subscription"
+        assert (
+            first_widget.plan_selector_title_label.toolTip()
+            == "This subscription is valid on any computer with this wallet"
+        )
         assert _plan_texts(widget.business_plan_widget) == ["10,00 EUR / year"]
         assert _plan_texts(first_widget) == ["2,00 EUR / month", "20,00 EUR / year"]
 


### PR DESCRIPTION
## Required

- `pre-commit install` before any commit. If pre-commit wasn't run for all commits, you can squash all commits   `git reset --soft $(git merge-base main HEAD) && git commit -m "squash"` and ensure the squashed commit is properly formatted
- All commits must be signed. If some are not, you can squash all commits   `git reset --soft $(git merge-base main HEAD) && git commit -m "squash"` and ensure the squashed commit is signed
- [ ] UI/Design/Menu changes **were** tested on _macOS_, because _macOS_ creates endless problems.  Optionally attach a screenshot.
 
## Optional

- [ ] Update all translations
- [ ] Appropriate pytests were added
- [ ] Documentation is updated
- [ ] If this PR affects builds or install artifacts, set the `Build-Relevant` label to trigger build workflows
- [ ] If this PR affects reproducible build outputs, set the `Reproducibility-Relevant` label to trigger the checksum comparison workflow
- [ ] Instruct AI 
```
create a concise summary (bullet points, no stats) for this pr and make a good title
```
