### PR TITLE
preserve wallet password during plugin registration

### DIFF
--- a/bitcoin_safe/gui/qt/main.py
+++ b/bitcoin_safe/gui/qt/main.py
@@ -2800,7 +2800,8 @@ class MainWindow(UnlockableMainWindow):
             "A wallet with id {name} is already open.  "
         ).format(name=qt_wallet.wallet.id)
 
-        qt_wallet.password = password
+        if password is not None:
+            qt_wallet.password = password
         if file_path:
             # very important! it saves the (possibly) new location into the qtwallet, such that
             # it can save exactly there again

--- a/tests/gui/qt/helpers.py
+++ b/tests/gui/qt/helpers.py
@@ -441,17 +441,29 @@ def save_wallet(
     test_config: UserConfig,
     wallet_name: str,
     save_button: QAbstractButton,
+    password: str | None = None,
+    qtbot: QtBot | None = None,
 ) -> Path:
     """Save wallet."""
     wallet_file = Path(test_config.config_dir) / f"{wallet_name}.wallet"
     with patch.object(
         QFileDialog, "getSaveFileName", return_value=(str(wallet_file), "All Files (*)")
     ) as mock_open:
-        with patch.object(PasswordCreation, "get_password", return_value="") as mock_password:
-            save_button.click()
+        if password is None:
+            with patch.object(PasswordCreation, "get_password", return_value="") as mock_password:
+                save_button.click()
 
-            QApplication.processEvents()
-            mock_password.assert_called_once()
+                QApplication.processEvents()
+                mock_password.assert_called_once()
+        else:
+            assert qtbot is not None
+
+            def enter_password(dialog: PasswordCreation) -> None:
+                dialog.password_input1.setText(password)
+                dialog.password_input2.setText(password)
+                dialog.submit_button.click()
+
+            do_modal_click(save_button, enter_password, qtbot, cls=PasswordCreation)
 
         mock_open.assert_called_once()
     return wallet_file

--- a/tests/gui/qt/test_history_range.py
+++ b/tests/gui/qt/test_history_range.py
@@ -185,12 +185,12 @@ def test_history_range_coupling(
             start_ts, end_ts = sorted((requested_start_ts, requested_end_ts))
             return float(int(start_ts)), float(int(end_ts))
 
-        full_end = qt_wallet.wallet_balance_chart.datetime_axis.max().toSecsSinceEpoch()
+        full_start = qt_wallet.wallet_balance_chart.datetime_axis.min().toSecsSinceEpoch()
         qtbot.waitUntil(lambda: hidden_rows() == set(), timeout=5_000)
 
         moving_timestamp_item = model.item(2, history_list.Columns.NLOCKTIME_TIME)
         assert moving_timestamp_item
-        moving_timestamp_item.setData(float(full_end + 1), MyItemDataRole.ROLE_CLIPBOARD_DATA)
+        moving_timestamp_item.setData(float(full_start - 1), MyItemDataRole.ROLE_CLIPBOARD_DATA)
         history_list.refresh_filters()
         assert history_list._date_range is None
         qtbot.waitUntil(lambda: hidden_rows() == set(), timeout=5_000)

--- a/tests/gui/qt/test_setup_wallet_custom.py
+++ b/tests/gui/qt/test_setup_wallet_custom.py
@@ -33,10 +33,12 @@ import gc
 import inspect
 import logging
 from datetime import datetime
+from pathlib import Path
 from unittest.mock import patch
 
 import bdkpython as bdk
 import pytest
+from bitcoin_safe_lib.storage import Storage
 from bitcoin_usb.address_types import AddressTypes
 from PyQt6.QtTest import QTest
 from PyQt6.QtWidgets import QApplication, QDialogButtonBox, QMessageBox
@@ -135,6 +137,7 @@ def test_custom_wallet_setup_custom_single_sig(
     wallet_name: str = "test_custom_wallet_setup_custom_single_sig",
 ) -> None:
     """Test custom wallet setup custom single sig."""
+    wallet_password = "test-password"
     frame = inspect.currentframe()
     assert frame
     shutter = Shutter(qtbot, name=f"{mytest_start_time.timestamp()}_{inspect.getframeinfo(frame).function}")
@@ -237,7 +240,7 @@ def test_custom_wallet_setup_custom_single_sig(
 
         change_to_single_sig()
 
-        def do_save_wallet() -> None:
+        def do_save_wallet() -> Path:
             """Do save wallet."""
             # Fill the seed fields and persist the wallet.
             key = list(qt_protowallet.wallet_descriptor_ui.keystore_uis.getAllTabData().values())[0]
@@ -258,19 +261,38 @@ def test_custom_wallet_setup_custom_single_sig(
 
             shutter.save(main_window)
 
-            save_wallet(
-                test_config=test_config,
-                wallet_name=wallet_name,
-                save_button=get_apply_button(qt_protowallet.wallet_descriptor_ui.button_box),
-            )
+            original_add_qt_wallet = main_window.add_qt_wallet
 
+            def add_qt_wallet_after_early_save(
+                qt_wallet: QTWallet,
+                file_path: str | None = None,
+                password: str | None = None,
+                focus: bool = True,
+            ) -> QTWallet:
+                # Reproduce a persistence callback saving before wallet registration.
+                qt_wallet.save()
+                assert Storage.has_password(qt_wallet.file_path)
+                return original_add_qt_wallet(qt_wallet, file_path, password, focus)
+
+            with patch.object(main_window, "add_qt_wallet", side_effect=add_qt_wallet_after_early_save):
+                wallet_file = save_wallet(
+                    test_config=test_config,
+                    wallet_name=wallet_name,
+                    save_button=get_apply_button(qt_protowallet.wallet_descriptor_ui.button_box),
+                    password=wallet_password,
+                    qtbot=qtbot,
+                )
+
+            assert Storage.has_password(str(wallet_file))
             assert len(main_window.tab_wallets.root.child_nodes) == 1, "there should be only 1 wallet open"
+            return wallet_file
 
-        do_save_wallet()
+        wallet_file = do_save_wallet()
 
         # Get the new QTWallet created after saving.
         qt_wallet = main_window.tab_wallets.root.findNodeByTitle(wallet_name).data
         assert isinstance(qt_wallet, QTWallet)
+        assert qt_wallet.password == wallet_password
 
         def do_all(qt_wallet: QTWallet) -> None:
             # Keep all operations in one scope to avoid lingering references to qt_wallet.
@@ -381,6 +403,7 @@ def test_custom_wallet_setup_custom_single_sig(
             new_wallet: QTWallet = main_window.tab_wallets.root.findNodeByTitle(wallet_name).data
             # After descriptor replace, a different first address should appear.
             assert new_wallet.wallet.get_addresses()[0] == "bcrt1qpmhcdhv2nyajtajpmwt74rqw7g38r6tyvtkctp"
+            assert new_wallet.password == wallet_password
 
             return new_wallet
 
@@ -409,6 +432,8 @@ def test_custom_wallet_setup_custom_single_sig(
             main_window.on_close_all_tx_tabs()
 
             shutter.save(main_window)
+
+        assert Storage.has_password(str(wallet_file))
 
         # Final screenshot after assertions.
         shutter.save(main_window)


### PR DESCRIPTION
## Required

- `pre-commit install` before any commit. If pre-commit wasn't run for all commits, you can squash all commits   `git reset --soft $(git merge-base main HEAD) && git commit -m "squash"` and ensure the squashed commit is properly formatted
- All commits must be signed. If some are not, you can squash all commits   `git reset --soft $(git merge-base main HEAD) && git commit -m "squash"` and ensure the squashed commit is signed
- [ ] UI/Design/Menu changes **were** tested on _macOS_, because _macOS_ creates endless problems.  Optionally attach a screenshot.
 
## Optional

- [ ] Update all translations
- [ ] Appropriate pytests were added
- [ ] Documentation is updated
- [ ] If this PR affects builds or install artifacts, set the `Build-Relevant` label to trigger build workflows
- [ ] If this PR affects reproducible build outputs, set the `Reproducibility-Relevant` label to trigger the checksum comparison workflow
- [ ] Instruct AI 
```
create a concise summary (bullet points, no stats) for this pr and make a good title
```
